### PR TITLE
Lighten muted console log color from #3a3850 to #6b6880

### DIFF
--- a/web/templates/logs.html
+++ b/web/templates/logs.html
@@ -13,7 +13,7 @@
     {% if sync_lines %}
     <div class="rounded-lg p-4 font-mono text-xs leading-relaxed max-h-72 overflow-y-auto space-y-0.5" style="background:#090910;border:1px solid var(--border);color:#c4c0dd">
       {% for line in sync_lines %}
-      <div style="{% if 'downloaded=' in line or '→' in line %}color:#34d399{% elif 'warn' in line or 'error' in line %}color:#fbbf24{% elif 'up-to-date' in line %}color:#3a3850{% endif %}">{{ line.strip() }}</div>
+      <div style="{% if 'downloaded=' in line or '→' in line %}color:#34d399{% elif 'warn' in line or 'error' in line %}color:#fbbf24{% elif 'up-to-date' in line %}color:#6b6880{% endif %}">{{ line.strip() }}</div>
       {% endfor %}
     </div>
     {% else %}

--- a/web/templates/sync.html
+++ b/web/templates/sync.html
@@ -56,7 +56,7 @@ function startSync() {
     line.textContent = e.data;
     if (e.data.includes('downloaded=') || e.data.includes('→')) line.style.color = '#34d399';
     else if (e.data.includes('[warn]') || e.data.includes('error')) line.style.color = '#fbbf24';
-    else if (e.data.includes('up-to-date')) line.style.color = '#3a3850';
+    else if (e.data.includes('up-to-date')) line.style.color = '#6b6880';
     lines.appendChild(line);
     lines.scrollTop = lines.scrollHeight;
   };


### PR DESCRIPTION
The up-to-date line color was nearly invisible against the #090910 terminal background. #6b6880 reads clearly as de-emphasised without disappearing into the dark background.

https://claude.ai/code/session_01CXDtFThkjh73Lwhwaj4Ykb