### PR TITLE
Fix non-root startup crash when runtime crontab is not writable.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,6 +37,10 @@ print(sanitize_sync_cron(load_settings().get("sync_cron")))
 PY
 )"
 echo "$CRON $RUNAS python3 /app/cron_enqueue_sync.py" > /tmp/crontab
+if [ "$PUID" != "0" ] || [ "$PGID" != "0" ]; then
+    chown "${PUID}:${PGID}" /tmp/crontab 2>/dev/null || true
+fi
+chmod 664 /tmp/crontab 2>/dev/null || true
 echo "manga-sync starting — schedule: $CRON | root: $MANGA_ROOT | data: $DATA_DIR | uid=${PUID} gid=${PGID}"
 
 $RUNAS uvicorn web.app:app --app-dir /app --host 0.0.0.0 --port 4649 --log-level warning &

--- a/web/app.py
+++ b/web/app.py
@@ -145,7 +145,12 @@ async def _startup():
     await loop.run_in_executor(None, _get_conn)
     # Keep runtime scheduler synced with persisted settings on boot.
     cron_expr = sanitize_sync_cron(load_settings().get("sync_cron"))
-    await loop.run_in_executor(None, _write_runtime_crontab, cron_expr)
+    try:
+        await loop.run_in_executor(None, _write_runtime_crontab, cron_expr)
+    except Exception as e:
+        # Do not fail app startup if crontab rewrite is not writable
+        # (e.g. non-root app user with root-owned crontab file).
+        print(f"[startup] warning: could not write runtime crontab '{RUNTIME_CRONTAB_PATH}': {e}")
     _job_worker_stop.clear()
     with contextlib.suppress(Exception):
         _enqueue_reconcile_job("startup")
@@ -1018,7 +1023,10 @@ async def save_settings_endpoint(
         "kavita_api_key": kavita_api_key.strip(),
     })
     if sanitize_sync_cron(before.get("sync_cron")) != normalized_sync_cron:
-        _write_runtime_crontab(normalized_sync_cron)
+        try:
+            _write_runtime_crontab(normalized_sync_cron)
+        except Exception as e:
+            print(f"[settings] warning: could not write runtime crontab '{RUNTIME_CRONTAB_PATH}': {e}")
     if list(before.get("root_folders") or []) != seen:
         with contextlib.suppress(Exception):
             _enqueue_reconcile_job("settings_root_folders_changed")


### PR DESCRIPTION
Set writable ownership/permissions on /tmp/crontab in entrypoint and treat runtime cron rewrite failures as warnings instead of fatal startup errors.