### PR TITLE
Add chapter provenance, series-language picker, and start-chapter semantics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 .manga-fix-log.json
 .sync.log
 CLAUDE.md
+.cursor/

--- a/comicinfo.py
+++ b/comicinfo.py
@@ -55,15 +55,25 @@ def build_comicinfo_xml(
                 .replace(">", "&gt;")
                 .replace('"', "&quot;"))
 
+    def _trim_chapter_num(value):
+        """Drop trailing ``.0`` for whole chapters; keep ``.5`` style fractions."""
+        if value is None:
+            return None
+        try:
+            num = float(value)
+        except (TypeError, ValueError):
+            return value
+        return int(num) if num.is_integer() else num
+
     fields = [
         ("Series",      series_title),
-        ("Number",      number),
+        ("Number",      _trim_chapter_num(number)),
         ("Volume",      int(volume_num) if volume_num is not None else None),
         ("Title",       chapter_title),
         ("Summary",     description),
         ("Writer",      ", ".join(authors)  if authors  else None),
         ("Penciller",   ", ".join(artists)  if artists  else None),
-        ("Publisher",   group_name),
+        ("Translator",  group_name),
         ("Genre",       ", ".join(tags)     if tags     else None),
         ("Count",       count),
         ("Web",         web),

--- a/db.py
+++ b/db.py
@@ -34,9 +34,15 @@ CREATE TABLE IF NOT EXISTS series (
     language                 TEXT    NOT NULL DEFAULT 'en',
     preferred_group          TEXT,
     preferred_groups_json    TEXT,
-    since                    REAL    NOT NULL DEFAULT 0,
+    -- ``start_chapter``: download chapters where chapter_num >= this value.
+    -- 0 means "download everything". Replaced the old ``since`` column whose
+    -- semantics were "skip chapters <= since" (download where chapter_num >
+    -- since) — the new ``>=`` form lets users type the first chapter they
+    -- actually want (e.g. 105 for Yotsuba) instead of guessing 104.999...
+    start_chapter            REAL    NOT NULL DEFAULT 0,
     exclude_from_fix         INTEGER NOT NULL DEFAULT 0,
     merge_volumes_override   INTEGER,
+    sync_configured          INTEGER NOT NULL DEFAULT 1,
     created_at               TEXT    NOT NULL,
     updated_at               TEXT    NOT NULL
 );
@@ -184,6 +190,44 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
     if "preferred_groups_json" not in cols:
         conn.execute("ALTER TABLE series ADD COLUMN preferred_groups_json TEXT")
         _migrate_preferred_groups_json(conn)
+    if "sync_configured" not in cols:
+        conn.execute(
+            "ALTER TABLE series ADD COLUMN sync_configured INTEGER NOT NULL DEFAULT 1"
+        )
+
+    # ``since`` (skip <= N) → ``start_chapter`` (download where >= N). Convert
+    # the value so the resulting download set is unchanged: 0 stays 0; any
+    # positive value becomes ``floor(value) + 1``, i.e. the smallest integer
+    # strictly greater than the old cutoff. ``CAST(real AS INTEGER)`` in
+    # SQLite truncates toward zero, which equals floor for non-negatives.
+    if "since" in cols and "start_chapter" not in cols:
+        conn.execute("ALTER TABLE series RENAME COLUMN since TO start_chapter")
+        conn.execute(
+            """
+            UPDATE series
+            SET start_chapter = CASE
+                WHEN start_chapter IS NULL OR start_chapter <= 0 THEN 0
+                ELSE CAST(start_chapter AS INTEGER) + 1
+            END
+            """
+        )
+
+    # One-shot: chapters with files but no real source identity were treated
+    # as ``downloaded`` by older builds, which leaked feed metadata
+    # (group_name, language, etc.) into ComicInfo for user-placed files. Tag
+    # those rows as ``on_disk`` so series-level data drives ComicInfo. Rows
+    # with ``source_chapter_id`` set are left alone — they may be real mdx
+    # downloads. Use the ``Reset chapter metadata`` UI to clear ambiguous
+    # cases (e.g. linked-only-for-covers like Yotsuba).
+    conn.execute(
+        """
+        UPDATE chapters
+        SET status = 'on_disk'
+        WHERE path IS NOT NULL
+          AND COALESCE(source_chapter_id, '') = ''
+          AND status != 'on_disk'
+        """
+    )
 
 
 def _migrate_preferred_groups_json(conn: sqlite3.Connection) -> None:
@@ -373,21 +417,29 @@ def migrate_json_configs(manga_root: str, conn: sqlite3.Connection) -> int:
         language = cfg.get("language", "en")
         preferred_group = cfg.get("translator") or None
         pj, pg = normalize_preferred_groups_storage(None, preferred_group)
-        since = float(cfg.get("since", 0))
+        # Legacy ``.mangadex.json`` files used ``since`` with skip-<= semantics.
+        # Convert to the new ``start_chapter`` (download chapter_num >= value):
+        # 0 stays 0, a positive cutoff becomes ``floor(value) + 1`` so the
+        # resulting download set is unchanged.
+        legacy_since = float(cfg.get("since", 0) or 0)
+        if legacy_since <= 0:
+            start_chapter = 0.0
+        else:
+            start_chapter = float(int(legacy_since) + 1)
 
         conn.execute("""
             INSERT INTO series (
                 title, path, language, preferred_group, preferred_groups_json,
-                since, created_at, updated_at
+                start_chapter, created_at, updated_at
             )
             VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(path) DO UPDATE SET
                 language              = excluded.language,
                 preferred_group       = excluded.preferred_group,
                 preferred_groups_json = excluded.preferred_groups_json,
-                since                 = excluded.since,
+                start_chapter         = excluded.start_chapter,
                 updated_at            = excluded.updated_at
-        """, (title, rel_path, language, pg, pj, since, now, now))
+        """, (title, rel_path, language, pg, pj, start_chapter, now, now))
 
         series_id = conn.execute(
             "SELECT id FROM series WHERE path = ?", (rel_path,)
@@ -446,7 +498,7 @@ def scan_disk_series(manga_root: str, conn: sqlite3.Connection) -> int:
             continue
         title = os.path.basename(root)
         conn.execute("""
-            INSERT INTO series (title, path, language, since, created_at, updated_at)
+            INSERT INTO series (title, path, language, start_chapter, created_at, updated_at)
             VALUES (?, ?, 'en', 0, ?, ?)
         """, (title, rel_path, now, now))
         added += 1
@@ -463,8 +515,8 @@ def get_all_series(conn: sqlite3.Connection) -> list[dict]:
     rows = conn.execute("""
         SELECT
             s.id, s.title, s.path, s.language, s.preferred_group,
-            s.preferred_groups_json, s.since,
-            s.exclude_from_fix, s.merge_volumes_override,
+            s.preferred_groups_json, s.start_chapter,
+            s.exclude_from_fix, s.merge_volumes_override, s.sync_configured,
             ss.source  AS source_name,
             ss.source_id,
             sm.description, sm.tags, sm.authors, sm.artists,
@@ -500,7 +552,7 @@ def get_all_series(conn: sqlite3.Connection) -> list[dict]:
             "language":      d["language"],
             "translator": (d["preferred_groups"][0] if d["preferred_groups"] else None),
             "translators":   d["preferred_groups"],
-            "since":         d["since"],
+            "start_chapter": d["start_chapter"],
             "status":        d.get("status"),
             "total_volumes": d.get("total_volumes"),
             "cover_filename":d.get("cover_filename"),
@@ -540,7 +592,7 @@ def get_series_by_path(conn: sqlite3.Connection, path: str) -> dict | None:
         "language":      d["language"],
         "translator": (d["preferred_groups"][0] if d["preferred_groups"] else None),
         "translators":   d["preferred_groups"],
-        "since":         d["since"],
+        "start_chapter": d["start_chapter"],
         "status":        d.get("status"),
         "total_volumes": d.get("total_volumes"),
         "cover_filename":d.get("cover_filename"),
@@ -562,7 +614,7 @@ def insert_series(
     path: str,
     title: str,
     language: str,
-    since: float,
+    start_chapter: float,
     source: str | None = None,
     source_id: str | None = None,
     cover_filename: str | None = None,
@@ -570,26 +622,28 @@ def insert_series(
     merge_volumes_override: int | None = None,
     preferred_groups_json: str | None = None,
     preferred_group: str | None = None,
+    sync_configured: int = 1,
 ) -> int:
     now = _now()
     pj, pg = normalize_preferred_groups_storage(preferred_groups_json, preferred_group)
     conn.execute("""
         INSERT INTO series (
-            title, path, language, preferred_group, preferred_groups_json, since,
-            exclude_from_fix, merge_volumes_override,
+            title, path, language, preferred_group, preferred_groups_json, start_chapter,
+            exclude_from_fix, merge_volumes_override, sync_configured,
             created_at, updated_at
         )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(path) DO UPDATE SET
             title                 = excluded.title,
             language              = excluded.language,
             preferred_group       = excluded.preferred_group,
             preferred_groups_json = excluded.preferred_groups_json,
-            since                 = excluded.since,
+            start_chapter         = excluded.start_chapter,
+            sync_configured       = excluded.sync_configured,
             updated_at            = excluded.updated_at
     """, (
-        title, path, language, pg, pj, since,
-        exclude_from_fix, merge_volumes_override,
+        title, path, language, pg, pj, start_chapter,
+        exclude_from_fix, merge_volumes_override, int(bool(sync_configured)),
         now, now,
     ))
 
@@ -622,7 +676,7 @@ def update_series(
     new_path: str,
     title: str,
     language: str,
-    since: float,
+    start_chapter: float,
     source: str | None = None,
     source_id: str | None = None,
     cover_filename: str | None = None,
@@ -630,21 +684,38 @@ def update_series(
     merge_volumes_override: int | None = None,
     preferred_groups_json: str | None = None,
     preferred_group: str | None = None,
+    sync_configured: int | None = None,
 ) -> bool:
     now = _now()
     pj, pg = normalize_preferred_groups_storage(preferred_groups_json, preferred_group)
-    cur = conn.execute("""
-        UPDATE series
-        SET path=?, title=?, language=?, preferred_group=?, preferred_groups_json=?,
-            since=?,
-            exclude_from_fix=?, merge_volumes_override=?,
-            updated_at=?
-        WHERE path=?
-    """, (
-        new_path, title, language, pg, pj, since,
-        exclude_from_fix, merge_volumes_override,
-        now, old_path,
-    ))
+    if sync_configured is None:
+        cur = conn.execute("""
+            UPDATE series
+            SET path=?, title=?, language=?, preferred_group=?, preferred_groups_json=?,
+                start_chapter=?,
+                exclude_from_fix=?, merge_volumes_override=?,
+                updated_at=?
+            WHERE path=?
+        """, (
+            new_path, title, language, pg, pj, start_chapter,
+            exclude_from_fix, merge_volumes_override,
+            now, old_path,
+        ))
+    else:
+        cur = conn.execute("""
+            UPDATE series
+            SET path=?, title=?, language=?, preferred_group=?, preferred_groups_json=?,
+                start_chapter=?,
+                exclude_from_fix=?, merge_volumes_override=?,
+                sync_configured=?,
+                updated_at=?
+            WHERE path=?
+        """, (
+            new_path, title, language, pg, pj, start_chapter,
+            exclude_from_fix, merge_volumes_override,
+            int(bool(sync_configured)),
+            now, old_path,
+        ))
     if cur.rowcount == 0:
         return False
 
@@ -671,12 +742,52 @@ def update_series(
     return True
 
 
+def reset_chapter_source_metadata(
+    conn: sqlite3.Connection, series_id: int
+) -> int:
+    """Detach per-chapter source metadata from files already on disk.
+
+    Catalog-only rows (``path IS NULL``) keep their source info so future
+    downloads still work. For files we already have on disk, all per-chapter
+    fields populated from the remote feed (title, group, language,
+    source_chapter_id) are wiped and the row is moved to ``status='on_disk'``,
+    which makes ComicInfo fall back to series-level data only.
+
+    ``has_comicinfo`` is reset to 0 so the next ComicInfo pass rewrites the
+    embedded XML.
+    """
+    cur = conn.execute(
+        """
+        UPDATE chapters
+        SET status = 'on_disk',
+            source = NULL,
+            source_chapter_id = NULL,
+            title = NULL,
+            group_name = NULL,
+            language = NULL,
+            publish_date = NULL,
+            has_comicinfo = 0
+        WHERE series_id = ? AND path IS NOT NULL
+        """,
+        (series_id,),
+    )
+    conn.commit()
+    return cur.rowcount or 0
+
+
 def unlink_series(conn: sqlite3.Connection, path: str) -> bool:
-    """Remove source links; keep series row, chapters, volumes."""
+    """Remove source links and detach per-chapter source metadata.
+
+    Files on disk and the series row stay; merging the unlink with the
+    chapter reset means ComicInfo regenerated afterwards will not retain
+    feed-only fields (e.g. a Vietnamese scanlator's name on an English
+    archive that only had the link for cover purposes).
+    """
     row = conn.execute("SELECT id FROM series WHERE path=?", (path,)).fetchone()
     if not row:
         return False
     conn.execute("DELETE FROM series_sources WHERE series_id=?", (row["id"],))
+    reset_chapter_source_metadata(conn, row["id"])
     conn.commit()
     return True
 
@@ -905,13 +1016,19 @@ def get_chapters_for_volume(
 
 
 def get_chapters_to_download(
-    conn: sqlite3.Connection, series_id: int, since: float
+    conn: sqlite3.Connection, series_id: int, start_chapter: float
 ) -> list[dict]:
+    """Return catalog rows that sync should pull (``chapter_num >= start_chapter``).
+
+    A ``start_chapter`` of 0 selects every catalog row. The series row stores
+    this as ``start_chapter`` and the UI exposes it as
+    *Start from chapter ≥*.
+    """
     rows = conn.execute("""
         SELECT * FROM chapters
-        WHERE series_id=? AND chapter_num > ? AND status='known' AND path IS NULL
+        WHERE series_id=? AND chapter_num >= ? AND status='known' AND path IS NULL
         ORDER BY chapter_num
-    """, (series_id, since)).fetchall()
+    """, (series_id, start_chapter)).fetchall()
     return [dict(r) for r in rows]
 
 
@@ -1038,23 +1155,47 @@ def scan_disk_files(
                 vol_id = upsert_volume(conn, series_id, vol_num)
 
             existing = conn.execute(
-                "SELECT id, path FROM chapters WHERE series_id=? AND chapter_num=?",
-                (series_id, ch_num)
+                "SELECT id, path, status FROM chapters"
+                " WHERE series_id=? AND chapter_num=?",
+                (series_id, ch_num),
             ).fetchone()
             if existing:
-                if existing["path"] != rel_path:
-                    conn.execute("""
+                # Only ``mark_chapter_downloaded`` (called right after a real
+                # ``mdx dl``) is allowed to mint a row as ``downloaded``. If we
+                # find a different file path here the file was placed/renamed
+                # outside the sync pipeline → treat it as on_disk and ignore
+                # any per-chapter source metadata for ComicInfo.
+                if existing["path"] == rel_path:
+                    if vol_id is not None:
+                        conn.execute(
+                            "UPDATE chapters SET volume_id=COALESCE(?, volume_id)"
+                            " WHERE id=?",
+                            (vol_id, existing["id"]),
+                        )
+                else:
+                    keep_downloaded = (
+                        existing["status"] == "downloaded"
+                        and existing["path"] is None
+                    )
+                    new_status = "downloaded" if keep_downloaded else "on_disk"
+                    conn.execute(
+                        """
                         UPDATE chapters
-                        SET path=?, file_size=?, status='downloaded',
+                        SET path=?, file_size=?, status=?,
                             volume_id=COALESCE(?, volume_id)
                         WHERE id=?
-                    """, (rel_path, size, vol_id, existing["id"]))
+                        """,
+                        (rel_path, size, new_status, vol_id, existing["id"]),
+                    )
             else:
-                conn.execute("""
+                conn.execute(
+                    """
                     INSERT INTO chapters
                         (series_id, volume_id, chapter_num, path, file_size, status)
-                    VALUES (?, ?, ?, ?, ?, 'downloaded')
-                """, (series_id, vol_id, ch_num, rel_path, size))
+                    VALUES (?, ?, ?, ?, ?, 'on_disk')
+                    """,
+                    (series_id, vol_id, ch_num, rel_path, size),
+                )
 
     # Null-out records for files that no longer exist
     if seen_paths:

--- a/manga-sync.py
+++ b/manga-sync.py
@@ -202,9 +202,26 @@ def _fetch_and_cache_meta(
             if rtype == "cover_art":
                 cover_filename = (rel.get("attributes") or {}).get("fileName")
 
-        agg = _api_get(f"/manga/{manga_id}/aggregate", {"translatedLanguage[]": language})
-        vols = agg.get("volumes") or {}
-        total_vols = len([k for k in vols if k not in ("none", "0")])
+        # Canonical tankōbon count: prefer attributes.lastVolume; fall back
+        # to /aggregate **without** a language filter (filtering by language
+        # under-counts series that aren't fully translated, e.g. only EN vols
+        # 1–11 published when the manga has 15 in print).
+        total_vols = 0
+        last_vol_raw = (attr.get("lastVolume") or "").strip()
+        if last_vol_raw:
+            try:
+                lv = int(float(last_vol_raw))
+                if lv > 0:
+                    total_vols = lv
+            except (ValueError, TypeError):
+                pass
+        if not total_vols:
+            try:
+                agg = _api_get(f"/manga/{manga_id}/aggregate", {})
+                vols = agg.get("volumes") or {}
+                total_vols = len([k for k in vols if k not in ("none", "0")])
+            except Exception:
+                total_vols = 0
 
         # Cache per-volume cover URLs so the merge step can embed them
         try:
@@ -212,9 +229,9 @@ def _fetch_and_cache_meta(
                 "manga[]": manga_id, "limit": 100, "order[volume]": "asc",
             })
             for item in covers_data.get("data", []):
-                attr    = item["attributes"]
-                vol_str = attr.get("volume")
-                fname   = attr.get("fileName")
+                cover_attr = item["attributes"]
+                vol_str    = cover_attr.get("volume")
+                fname      = cover_attr.get("fileName")
                 if vol_str and fname:
                     try:
                         cover_url = (
@@ -294,13 +311,28 @@ def _sync_chapters_to_db(
             except (ValueError, TypeError):
                 pass
 
+        # Never propagate per-chapter feed metadata (title, group, source_id,
+        # publish_date) onto a row whose file is already on disk. The whole
+        # point of ``status='on_disk'`` is that ComicInfo for that file uses
+        # series-level info only — re-tagging it on every sync would undo
+        # that. We still ensure the volume mapping so merge logic can reason
+        # about coverage.
+        existing = conn.execute(
+            "SELECT id, path, status FROM chapters"
+            " WHERE series_id=? AND chapter_num=?",
+            (series_id, ch_num),
+        ).fetchone()
+        if existing and (existing["path"] or existing["status"] == "on_disk"):
+            if vol_id is not None:
+                assign_chapter_to_volume(conn, existing["id"], vol_id)
+            continue
+
         chapter_id = upsert_chapter(
             conn, series_id, ch_num,
             source="mangadex",
             source_chapter_id=picked_id,
             title=picked.title,
             group_name=picked.group,
-            language=language,
             publish_date=picked.publish_date,
         )
 
@@ -782,14 +814,29 @@ def _ensure_comicinfo_all(
         vol_num_by_vol_id[row["id"]] = row["volume_num"]
 
     injected_ch = 0
+    total_ch    = len(ch_rows)
 
-    for ch in ch_rows:
+    for idx, ch in enumerate(ch_rows, start=1):
         cbz_path = os.path.join(MANGA_ROOT, ch["path"])
         if not os.path.exists(cbz_path):
             continue
-        # Strict rule: take MangaDex chapter title as-is, otherwise keep empty.
-        ch_title = (ch.get("title") or "").strip() or None
         vol_num = vol_num_by_vol_id.get(ch.get("volume_id")) if ch.get("volume_id") else None
+        # ``on_disk`` rows never carry trustworthy per-chapter source info —
+        # the file got there outside the sync pipeline (user import, manual
+        # rip, etc.). Use only series-level fields for ComicInfo so we do
+        # not stamp foreign translator names / chapter titles / chapter URLs
+        # onto archives we did not download ourselves.
+        if ch.get("status") == "on_disk":
+            ch_title = None
+            group_name = None
+            ch_web = series_web
+        else:
+            ch_title = (ch.get("title") or "").strip() or None
+            group_name = ch.get("group_name")
+            ch_id = ch.get("source_chapter_id")
+            ch_web = (
+                f"https://mangadex.org/chapter/{ch_id}" if ch_id else series_web
+            )
         xml = build_comicinfo_xml(
             series_title=series_title,
             number=ch["chapter_num"],
@@ -798,20 +845,22 @@ def _ensure_comicinfo_all(
             description=description,
             authors=authors,
             artists=artists,
-            group_name=ch.get("group_name"),
-            language=ch.get("language") or language,
+            group_name=group_name,
+            language=language,
             year=year,
             tags=tags,
             content_rating=content_rating,
             page_count=count_pages(cbz_path),
-            web=series_web,
+            web=ch_web,
         )
         if inject_comicinfo(cbz_path, xml, overwrite=True):
             mark_chapter_comicinfo(conn, ch["id"])
             injected_ch += 1
+            _log(f"[{label}] ComicInfo {idx}/{total_ch}: {os.path.basename(cbz_path)}")
 
     injected_vol = 0
-    for vol in vol_rows:
+    total_vol    = len(vol_rows)
+    for idx, vol in enumerate(vol_rows, start=1):
         cbz_path = os.path.join(MANGA_ROOT, vol["path"])
         if not os.path.exists(cbz_path):
             continue
@@ -841,6 +890,7 @@ def _ensure_comicinfo_all(
         if inject_comicinfo(cbz_path, xml, overwrite=True):
             mark_volume_comicinfo(conn, vol["id"])
             injected_vol += 1
+            _log(f"[{label}] ComicInfo vol {idx}/{total_vol}: {os.path.basename(cbz_path)}")
     _log(f"[{label}] ComicInfo done: {injected_ch} chapter(s), {injected_vol} volume(s) updated")
 
 
@@ -908,7 +958,7 @@ def _sync_one_series(
     language    = series_row.get("language", "en")
     prefs       = _series_preferred_groups(series_row)
     group       = prefs[0] if prefs else None
-    since       = float(series_row.get("since") or 0)
+    start_chapter = float(series_row.get("start_chapter") or 0)
     manga_id    = series_row.get("source_id")
     source_name = series_row.get("source_name") or "mangadex"
     name        = series_row.get("name") or os.path.basename(series_path)
@@ -923,6 +973,17 @@ def _sync_one_series(
     if is_metadata_stale(meta and meta.get("fetched_at")):
         meta = _fetch_and_cache_meta(manga_id, series_id, source_name, language, conn)
 
+    # Linked-only (no download options chosen yet): refresh metadata+ComicInfo,
+    # do not pull the chapter feed or queue downloads.
+    if not series_row.get("sync_configured"):
+        _log(f"[{name}] sync not configured — skipping feed/download")
+        _ensure_comicinfo_all(
+            series_id, series_dir, conn, meta, language,
+            series_web=series_web, series_label=name,
+        )
+        update_source_sync_time(conn, series_id, source_name)
+        return False
+
     # Sync chapter feed → DB
     try:
         _sync_chapters_to_db(manga_id, language, prefs, series_id, conn)
@@ -930,7 +991,7 @@ def _sync_one_series(
         _log(f"[{name}] feed error: {e}")
         return False
 
-    to_download = get_chapters_to_download(conn, series_id, since)
+    to_download = get_chapters_to_download(conn, series_id, start_chapter)
 
     if not to_download:
         _log(f"[{name}] up-to-date")
@@ -970,7 +1031,7 @@ def _sync_one_series(
                         vol_num = vr["volume_num"]
                 desired_stem = _apply_chapter_template(
                     ch_naming,
-                    lang=ch_row.get("language") or language,
+                    lang=language,
                     group=ch_row.get("group_name") or "",
                     title=name,
                     vol_num=vol_num,

--- a/web/app.py
+++ b/web/app.py
@@ -24,6 +24,68 @@ MDEX_BASE  = "https://api.mangadex.org"
 MDEX_COVERS = "https://uploads.mangadex.org/covers"
 CONTENT_RATINGS = ["safe", "suggestive", "erotica", "pornographic"]
 
+# ISO-style codes aligned with MangaDex ``translatedLanguage`` (ComicInfo LanguageISO).
+_SERIES_LANGUAGE_CHOICES_BASE = [
+    ("en", "English (en)"),
+    ("ja", "Japanese (ja)"),
+    ("ko", "Korean (ko)"),
+    ("zh", "Chinese (zh)"),
+    ("zh-hk", "Chinese Traditional (zh-hk)"),
+    ("es", "Spanish (es)"),
+    ("fr", "French (fr)"),
+    ("de", "German (de)"),
+    ("it", "Italian (it)"),
+    ("pt-br", "Portuguese Brazil (pt-br)"),
+    ("ru", "Russian (ru)"),
+    ("pl", "Polish (pl)"),
+    ("tr", "Turkish (tr)"),
+    ("vi", "Vietnamese (vi)"),
+    ("id", "Indonesian (id)"),
+    ("th", "Thai (th)"),
+    ("ar", "Arabic (ar)"),
+]
+
+
+def _series_language_choices(
+    current: str | None,
+    available: list[str] | None = None,
+) -> list[tuple[str, str]]:
+    """Dropdown rows for series-language picker.
+
+    Preserves unknown codes already in the DB (so we never silently mutate a
+    stored value), and annotates entries that MangaDex actually has
+    translations for so the user picks something the feed can actually
+    deliver.
+    """
+    cur_raw = (current or "en").strip()
+    cur_key = cur_raw.lower()
+    avail = {(a or "").strip().lower() for a in (available or []) if a}
+    base_codes = {c for c, _ in _SERIES_LANGUAGE_CHOICES_BASE}
+    rows: list[tuple[str, str]] = []
+    for code, label in _SERIES_LANGUAGE_CHOICES_BASE:
+        if avail and code in avail:
+            rows.append((code, f"{label} · on MangaDex"))
+        else:
+            rows.append((code, label))
+    if cur_key and cur_key not in base_codes:
+        rows.insert(0, (cur_key, f"{cur_raw} (stored)"))
+    return rows
+
+
+def _pick_default_series_language(available: list[str]) -> str:
+    """Bias toward English when MangaDex offers it.
+
+    The previous default — ``available_langs[0]`` — picked whatever order
+    MangaDex returned, which is *not* a meaningful preference and is how
+    English libraries ended up tagged with ``vi`` after a one-click link.
+    """
+    norm = [(a or "").strip().lower() for a in (available or []) if a]
+    if "en" in norm:
+        return "en"
+    if norm:
+        return norm[0]
+    return "en"
+
 _WEB_DIR = os.path.dirname(os.path.abspath(__file__))
 _REPO_ROOT = os.path.dirname(_WEB_DIR)
 MANGA_SYNC_SCRIPT = os.path.join(_REPO_ROOT, "manga-sync.py")
@@ -367,7 +429,7 @@ def _apply_naming_template(
 
 
 def _mdex_tankobon_volume_count_from_aggregate(agg) -> int:
-    """Buckets in MangaDex /aggregate for translated chapters.
+    """Buckets in MangaDex /aggregate.
 
     Keys ``none`` and ``0`` are not numbered tankōbon volumes: ``0`` holds
     specials/extras that often have no ``chapter`` number in the API, so they
@@ -377,6 +439,41 @@ def _mdex_tankobon_volume_count_from_aggregate(agg) -> int:
         return 0
     vols = agg.get("volumes") or {}
     return len([k for k in vols if k not in ("none", "0")])
+
+
+def _parse_last_volume(attr: dict | None) -> int:
+    """Parse ``attributes.lastVolume`` (canonical tankōbon count) into an int.
+
+    Empty / non-numeric values return 0 so callers fall back to aggregate.
+    """
+    if not attr:
+        return 0
+    raw = (attr.get("lastVolume") or "").strip()
+    if not raw:
+        return 0
+    try:
+        n = int(float(raw))
+        return n if n > 0 else 0
+    except (ValueError, TypeError):
+        return 0
+
+
+def _resolve_total_volumes(attr: dict | None, manga_id: str) -> int:
+    """Best-effort canonical tankōbon count for parity display.
+
+    Prefers ``attributes.lastVolume`` (set for most completed manga); falls
+    back to ``/aggregate`` **without** a language filter — that bucket count
+    matches what MangaDex itself displays on the title page, instead of just
+    the volumes that happen to be translated to the user's chosen language.
+    """
+    n = _parse_last_volume(attr)
+    if n:
+        return n
+    try:
+        agg = _mdex_get(f"/manga/{manga_id}/aggregate", {})
+    except Exception:
+        return 0
+    return _mdex_tankobon_volume_count_from_aggregate(agg)
 
 
 def _scan_settings_naming_issues() -> list[tuple[str, str, str]]:
@@ -404,7 +501,7 @@ def _scan_settings_naming_issues() -> list[tuple[str, str, str]]:
             c.chapter_num,
             c.title AS chapter_title,
             c.group_name,
-            c.language AS chapter_language,
+            c.status AS chapter_status,
             v.volume_num,
             s.path AS series_path,
             s.language AS series_language,
@@ -421,14 +518,18 @@ def _scan_settings_naming_issues() -> list[tuple[str, str, str]]:
         old_name = os.path.basename(old_path)
         old_dir = os.path.dirname(old_path)
         stem, ext = os.path.splitext(old_name)
+        # Files we did not download ourselves (status='on_disk') must be
+        # named with series-level info only — no per-chapter title/group
+        # leaking into the proposed filename.
+        is_on_disk = row["chapter_status"] == "on_disk"
         new_stem = _apply_naming_template(
             chapter_tpl,
-            language=row["chapter_language"] or row["series_language"] or "en",
-            group=row["group_name"] or row["preferred_group"] or "",
+            language=row["series_language"] or "en",
+            group="" if is_on_disk else (row["group_name"] or row["preferred_group"] or ""),
             title=os.path.basename(row["series_path"]),
             volume_num=row["volume_num"],
             chapter_num=row["chapter_num"],
-            chapter_title=row["chapter_title"] or "",
+            chapter_title="" if is_on_disk else (row["chapter_title"] or ""),
         )
         # Guard against dangerous suggestions that drop chapter identity.
         ch_token = _format_num(row["chapter_num"])
@@ -753,7 +854,7 @@ def _realpath_under_series(series_rel: str, file_rel: str) -> str | None:
 def _comicinfo_fields_to_xml(fields: dict[str, str]) -> str:
     allowed_order = [
         "Series", "Number", "Volume", "Title", "Summary",
-        "Writer", "Penciller", "Publisher", "Genre", "Count",
+        "Writer", "Penciller", "Translator", "Publisher", "Genre", "Count",
         "Web", "LanguageISO", "Year", "Manga", "AgeRating", "PageCount",
     ]
     lines = [
@@ -844,10 +945,9 @@ async def series_details_page(request: Request, path: str):
                         authors.append(rname)
                     elif rtype == "artist":
                         artists.append(rname)
-                agg = await loop.run_in_executor(
-                    None, lambda: _mdex_get(f"/manga/{row['source_id']}/aggregate", {"translatedLanguage[]": row.get("language", "en")})
+                total_vols = await loop.run_in_executor(
+                    None, lambda: _resolve_total_volumes(attr, row["source_id"])
                 )
-                total_vols = _mdex_tankobon_volume_count_from_aggregate(agg)
                 _db.upsert_series_metadata(
                     conn, row["id"], row.get("source_name") or "mangadex",
                     description=description,
@@ -861,10 +961,9 @@ async def series_details_page(request: Request, path: str):
                 )
                 row = _db.get_series_by_path(conn, path) or row
             else:
-                agg = await loop.run_in_executor(
-                    None, lambda: _mdex_get(f"/manga/{row['source_id']}/aggregate", {"translatedLanguage[]": row.get("language", "en")})
+                total_vols = await loop.run_in_executor(
+                    None, lambda: _resolve_total_volumes(None, row["source_id"])
                 )
-                total_vols = _mdex_tankobon_volume_count_from_aggregate(agg)
                 stored = row.get("total_volumes")
                 if stored is None or int(stored) != int(total_vols):
                     _db.upsert_series_metadata(
@@ -1158,6 +1257,52 @@ async def get_manga_setup(request: Request, manga_id: str):
                  "subdirs": get_subdirs(), **groups_data})
 
 
+@app.get("/api/manga/{manga_id}/link-preview", response_class=HTMLResponse)
+async def get_manga_link_preview(request: Request, manga_id: str):
+    """Fast step-1 panel: link manga ID only (no feed/group scans)."""
+    loop = asyncio.get_event_loop()
+    try:
+        data = await loop.run_in_executor(
+            None, lambda: _mdex_get(f"/manga/{manga_id}", {"includes[]": "cover_art"})
+        )
+    except Exception as e:
+        return HTMLResponse(f'<p class="text-red-500 text-sm">Could not load manga: {e}</p>')
+
+    manga_data = data["data"]
+    attr   = manga_data["attributes"]
+    title  = (attr.get("title") or {}).get("en") or \
+             next(iter((attr.get("title") or {}).values()), "Unknown")
+    status = attr.get("status", "unknown")
+    year   = attr.get("year")
+    available_langs = attr.get("availableTranslatedLanguages") or []
+
+    cover_url = None
+    cover_filename = ""
+    for rel in manga_data.get("relationships", []):
+        if rel["type"] == "cover_art":
+            fname = (rel.get("attributes") or {}).get("fileName")
+            if fname:
+                cover_filename = fname
+                cover_url      = _cover_url(manga_id, fname)
+                break
+
+    default_lang = _pick_default_series_language(available_langs)
+
+    return templates.TemplateResponse(request=request, name="partials/manga_link_confirm.html",
+        context={
+            "manga_id": manga_id,
+            "title": title,
+            "status": status,
+            "year": year,
+            "cover_url": cover_url,
+            "cover_filename": cover_filename,
+            "available_langs": available_langs,
+            "default_lang": default_lang,
+            "series_language_choices": _series_language_choices(default_lang, available_langs),
+            "subdirs": get_subdirs(),
+        })
+
+
 @app.get("/api/manga/{manga_id}/langs")
 async def get_manga_langs(manga_id: str):
     loop = asyncio.get_event_loop()
@@ -1229,12 +1374,13 @@ def _parse_merge_volumes_override(raw: str | None) -> int | None:
 
 @app.post("/api/series")
 async def add_series(
+    request: Request,
     manga_id:       str   = Form(...),
     title:          str   = Form(...),
     subfolder:      str   = Form(""),
     language:       str   = Form("en"),
     preferred_groups_json: str = Form("[]"),
-    since:          str   = Form("0"),
+    start_chapter:  str   = Form("0"),
     cover_filename: str   = Form(""),
     exclude_from_fix: str = Form("false"),
     merge_volumes_override: str = Form(""),
@@ -1245,12 +1391,16 @@ async def add_series(
     rel_path   = os.path.relpath(series_dir, MANGA_ROOT)
 
     try:
-        since_f = float(since) if since else 0.0
+        start_f = float(start_chapter) if start_chapter else 0.0
     except ValueError:
-        since_f = 0.0
+        start_f = 0.0
 
     excl = 1 if exclude_from_fix == "true" else 0
     merge_ov = _parse_merge_volumes_override(merge_volumes_override)
+
+    accept = request.headers.get("accept") or ""
+    link_only = "application/json" in accept
+    sync_conf = 0 if link_only else 1
 
     loop = asyncio.get_event_loop()
     await loop.run_in_executor(None, lambda: _db.insert_series(
@@ -1258,14 +1408,17 @@ async def add_series(
         path=rel_path,
         title=title,
         language=language,
-        since=since_f,
+        start_chapter=start_f,
         source="mangadex" if manga_id else None,
         source_id=manga_id or None,
         cover_filename=cover_filename.strip() or None,
         exclude_from_fix=excl,
         merge_volumes_override=merge_ov,
         preferred_groups_json=preferred_groups_json.strip() or None,
+        sync_configured=sync_conf,
     ))
+    if link_only:
+        return JSONResponse({"ok": True, "path": rel_path}, status_code=201)
     target = f"/series/{parse.quote(rel_path, safe='/')}"
     return RedirectResponse(target, status_code=303)
 
@@ -1325,6 +1478,10 @@ async def delete_series(path: str):
 
 @app.get("/api/series/{path:path}/edit", response_class=HTMLResponse)
 async def edit_series_form(request: Request, path: str):
+    """General settings: location, folder name, series language, exclude-from-fix.
+
+    Sync-only settings (groups, chapter cutoff) use ``grab-options``.
+    """
     conn = _get_conn()
     row  = _db.get_series_by_path(conn, path)
     if not row:
@@ -1334,29 +1491,82 @@ async def edit_series_form(request: Request, path: str):
     folder_name = parts[-1]
     subfolder   = "/".join(parts[:-1])
 
-    mov = row.get("merge_volumes_override")
     prefs = row.get("preferred_groups") or []
     manga_id = row["config"].get("id", "") or ""
-    # Keep modal open fast: render saved preferences only.
-    # Fresh group availability can be pulled on demand via "Refetch".
-    groups_list = [(name, None, False) for name in prefs]
+    lang_norm = (row.get("language") or "en").strip().lower()
 
-    return templates.TemplateResponse(request=request, name="partials/series_edit.html",
+    return templates.TemplateResponse(request=request, name="partials/series_edit_general.html",
         context={
             "path":                path,
             "manga_id":            manga_id,
             "manga_title":         folder_name,
-            "current_lang":        row.get("language", "en"),
+            "current_lang":        lang_norm,
+            "series_language_choices": _series_language_choices(row.get("language")),
             "current_preferred_groups_json": json.dumps(prefs, ensure_ascii=False),
-            "current_translator_display": ", ".join(prefs),
-            "current_since":       row.get("since", 0),
+            "current_start":       row.get("start_chapter", 0),
             "current_cover_filename": row["config"].get("cover_filename", ""),
             "exclude_from_fix":    bool(row.get("exclude_from_fix")),
-            "merge_volumes_override": mov,
             "folder_name":         folder_name,
             "subfolder":           subfolder,
             "subdirs":             get_subdirs(),
-            "groups":              groups_list,
+        })
+
+
+@app.get("/api/series/{path:path}/grab-options", response_class=HTMLResponse)
+async def get_grab_options_form(request: Request, path: str):
+    """Optional step 2 after linking: language, groups, start chapter (PUT same series)."""
+    conn = _get_conn()
+    row  = _db.get_series_by_path(conn, path)
+    if not row:
+        raise HTTPException(404, "Series not found")
+
+    manga_id = (row.get("config") or {}).get("id") or row.get("source_id")
+    if not manga_id:
+        raise HTTPException(400, "Series is not linked to MangaDex")
+
+    loop = asyncio.get_event_loop()
+    cur_lang = row.get("language") or "en"
+
+    lang_counts: dict[str, int] = {}
+    try:
+        data = await loop.run_in_executor(
+            None, lambda: _mdex_get(f"/manga/{manga_id}", {})
+        )
+        available_langs = data["data"]["attributes"].get("availableTranslatedLanguages") or []
+        if available_langs:
+            tasks = [
+                loop.run_in_executor(None, _lang_chapter_count, manga_id, lang)
+                for lang in available_langs[:10]
+            ]
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            for r in results:
+                if isinstance(r, tuple) and r[1] > 0:
+                    lang_counts[r[0]] = r[1]
+        lang_counts = dict(sorted(lang_counts.items(), key=lambda x: x[1], reverse=True))
+    except Exception:
+        pass
+
+    groups_data = await _fetch_groups(manga_id, cur_lang)
+
+    parts       = path.split("/")
+    folder_name = parts[-1]
+    subfolder   = "/".join(parts[:-1])
+
+    prefs = row.get("preferred_groups") or []
+
+    return templates.TemplateResponse(request=request, name="partials/manga_grab_options.html",
+        context={
+            "path": path,
+            "manga_id": manga_id,
+            "folder_name": folder_name,
+            "subfolder": subfolder,
+            "cover_filename": row["config"].get("cover_filename") or "",
+            "current_lang": cur_lang,
+            "lang_counts": lang_counts,
+            "current_start": row.get("start_chapter", 0),
+            "exclude_from_fix": bool(row.get("exclude_from_fix")),
+            "current_preferred_groups_json": json.dumps(prefs, ensure_ascii=False),
+            **groups_data,
         })
 
 
@@ -1368,10 +1578,11 @@ async def update_series(
     subfolder:      str   = Form(""),
     language:       str   = Form("en"),
     preferred_groups_json: str = Form("[]"),
-    since:          str   = Form("0"),
+    start_chapter:  str   = Form("0"),
     cover_filename: str   = Form(""),
     exclude_from_fix: str = Form("false"),
     merge_volumes_override: str = Form(""),
+    mark_sync_configured: str = Form(""),
 ):
     # path here is the URL route parameter (old path)
     old_dir    = os.path.join(MANGA_ROOT, path)
@@ -1384,28 +1595,30 @@ async def update_series(
         shutil.move(old_dir, new_dir)
 
     try:
-        since_f = float(since) if since else 0.0
+        start_f = float(start_chapter) if start_chapter else 0.0
     except ValueError:
-        since_f = 0.0
+        start_f = 0.0
 
     excl = 1 if exclude_from_fix == "true" else 0
     merge_ov = _parse_merge_volumes_override(merge_volumes_override)
 
     conn = _get_conn()
     loop = asyncio.get_event_loop()
+    sync_conf: int | None = 1 if mark_sync_configured == "true" else None
     await loop.run_in_executor(None, lambda: _db.update_series(
         conn,
         old_path=path,
         new_path=new_rel,
         title=title,
         language=language,
-        since=since_f,
+        start_chapter=start_f,
         source="mangadex" if manga_id else None,
         source_id=manga_id or None,
         cover_filename=cover_filename.strip() or None,
         exclude_from_fix=excl,
         merge_volumes_override=merge_ov,
         preferred_groups_json=preferred_groups_json.strip() or None,
+        sync_configured=sync_conf,
     ))
     return Response(status_code=204)
 
@@ -1759,6 +1972,23 @@ async def series_compact_volumes(path: str):
     return JSONResponse({"ok": proc.returncode == 0, "log": log_text})
 
 
+@app.post("/api/series/{path:path}/reset-source-metadata")
+async def series_reset_source_metadata(path: str):
+    """Detach per-chapter source metadata from files already on disk.
+
+    Use this when a series was linked just for covers / catalog progress and
+    chapter rows ended up with foreign metadata (e.g. ``LanguageISO=vi`` on
+    English archives). Catalog rows that have no file are left intact, so
+    sync can still discover and download missing chapters afterwards.
+    """
+    conn = _get_conn()
+    row = _db.get_series_by_path(conn, path)
+    if not row:
+        raise HTTPException(404, "Series not found")
+    n = _db.reset_chapter_source_metadata(conn, row["id"])
+    return JSONResponse({"ok": True, "reset": int(n)})
+
+
 @app.post("/api/series/{path:path}/delete-files")
 async def series_delete_files(path: str, body: DeleteSeriesFilesBody):
     """Delete chapter/volume archive files on disk for this series; DB is reconciled via scan."""
@@ -2017,7 +2247,7 @@ async def skip_series_from_fix(series_path: str = Form(...)):
             new_path=series_path,
             title=row["title"],
             language=row["language"],
-            since=float(row.get("since") or 0),
+            start_chapter=float(row.get("start_chapter") or 0),
             source=row.get("source_name"),
             source_id=row.get("source_id"),
             cover_filename=row["config"].get("cover_filename"),

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -210,6 +210,27 @@
       border-radius: 16px;
       box-shadow: 0 24px 64px rgba(0,0,0,.6);
     }
+    .modal-spinner {
+      width: 32px;
+      height: 32px;
+      border-radius: 50%;
+      border: 2.5px solid var(--border);
+      border-top-color: var(--accent);
+      animation: modal-spin .9s linear infinite;
+    }
+    .inline-spinner {
+      display: inline-block;
+      vertical-align: -2px;
+      width: 14px;
+      height: 14px;
+      border-radius: 50%;
+      border: 2px solid var(--border);
+      border-top-color: var(--accent);
+      animation: modal-spin .9s linear infinite;
+    }
+    @keyframes modal-spin {
+      to { transform: rotate(360deg); }
+    }
 
     /* ── Terminal output ───────────────────────────────────── */
     .bg-slate-900 {
@@ -441,6 +462,38 @@
         _closeConfirmModal(false);
       }
     });
+    function _showModalLoading(label) {
+      var body = document.getElementById('modal-body');
+      if (!body) return;
+      var safeLabel = String(label || 'Loading…')
+        .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+      body.innerHTML =
+        '<div class="flex flex-col items-center justify-center gap-4 py-12">' +
+          '<div class="modal-spinner" role="status" aria-label="Loading"></div>' +
+          '<p class="text-sm text-center" style="color:var(--text-muted);font-family:\'Syne\',sans-serif">' +
+            safeLabel +
+          '</p>' +
+        '</div>';
+      openModal();
+    }
+    function _showModalError(label) {
+      var body = document.getElementById('modal-body');
+      if (!body) return;
+      var safeLabel = String(label || 'Request failed')
+        .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+      body.innerHTML =
+        '<div class="flex flex-col items-start gap-3 py-2">' +
+          '<h2 class="text-base font-semibold" style="font-family:\'Syne\',sans-serif;color:var(--text)">Could not load</h2>' +
+          '<p class="text-sm" style="color:var(--text-muted)">' + safeLabel + '</p>' +
+          '<button type="button" onclick="closeModal()" class="text-xs px-3 py-2 rounded-lg border" style="border-color:var(--border-mid);color:var(--text-muted)">Close</button>' +
+        '</div>';
+    }
+    function _modalLoadingLabelFor(url) {
+      if (!url) return 'Loading…';
+      if (url.indexOf('/grab-options') !== -1) return 'Fetching scanlation groups from MangaDex…\nThis can take a few seconds.';
+      if (url.indexOf('/edit') !== -1) return 'Loading settings…';
+      return 'Loading…';
+    }
     function afterGroupPickerInjected() {
       var list = document.getElementById('group-picker-list');
       if (!list) return;
@@ -452,6 +505,31 @@
       syncPreferredGroupsFromPicker();
       _syncManualDisplayFromHidden();
     }
+
+    // Open the modal immediately when an htmx request targets #modal-body —
+    // otherwise a slow endpoint (e.g. grab-options polls MangaDex feeds) makes
+    // the page feel frozen until the response arrives.
+    document.addEventListener('htmx:beforeRequest', function(e) {
+      if (!e.detail || !e.detail.target) return;
+      if (e.detail.target.id !== 'modal-body') return;
+      var elt = e.detail.elt;
+      var url = elt && (elt.getAttribute('hx-get') || elt.getAttribute('hx-post')
+                        || elt.getAttribute('hx-put') || elt.getAttribute('hx-delete')) || '';
+      _showModalLoading(_modalLoadingLabelFor(url));
+    });
+
+    document.addEventListener('htmx:responseError', function(e) {
+      if (!e.detail || !e.detail.target) return;
+      if (e.detail.target.id !== 'modal-body') return;
+      var status = (e.detail.xhr && e.detail.xhr.status) || '';
+      _showModalError('Server returned ' + status + '. Try again, or close this dialog.');
+    });
+
+    document.addEventListener('htmx:sendError', function(e) {
+      if (!e.detail || !e.detail.target) return;
+      if (e.detail.target.id !== 'modal-body') return;
+      _showModalError('Network error — could not reach the server.');
+    });
 
     document.addEventListener('htmx:afterSwap', e => {
       if (e.target.id === 'modal-body') {

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -327,16 +327,10 @@
       <div class="card-actions">
         {% if s.linked %}
         <button class="act-btn accent" onclick="seriesSync(this)" data-path="{{ s.path }}">Sync</button>
-        <button class="act-btn muted"  onclick="seriesCovers(this)" data-path="{{ s.path }}">Covers</button>
         <a href="/series/{{ s.path }}" class="act-btn muted"
            style="text-decoration:none;display:inline-flex;align-items:center">Details</a>
         <a href="https://mangadex.org/title/{{ s.config.id }}" target="_blank" rel="noopener"
-           class="act-btn muted" style="text-decoration:none;display:inline-flex;align-items:center" title="View on MangaDex">↗</a>
-        <button class="act-btn danger"
-                hx-delete="/api/series/{{ s.path }}"
-                hx-target="closest .series-item"
-                hx-swap="outerHTML"
-                hx-confirm="Remove '{{ s.name }}' from sync? (files stay on disk)">✕</button>
+           class="act-btn muted" style="text-decoration:none;display:inline-flex;align-items:center" title="View on MangaDex">MangaDex ↗</a>
         {% else %}
         <a href="/series?q={{ s.name | urlencode }}&folder={{ s.name | urlencode }}&sub={{ s.subfolder | urlencode }}" class="act-btn accent"
            style="text-decoration:none;display:inline-flex;align-items:center">Link →</a>
@@ -381,16 +375,10 @@
     <div class="list-actions">
       {% if s.linked %}
       <button class="act-btn accent" onclick="seriesSync(this)" data-path="{{ s.path }}">Sync</button>
-      <button class="act-btn muted"  onclick="seriesCovers(this)" data-path="{{ s.path }}">Covers</button>
       <a href="/series/{{ s.path }}" class="act-btn muted"
          style="text-decoration:none;display:inline-flex;align-items:center">Details</a>
       <a href="https://mangadex.org/title/{{ s.config.id }}" target="_blank" rel="noopener"
-         class="act-btn muted" style="text-decoration:none;display:inline-flex;align-items:center" title="View on MangaDex">↗</a>
-      <button class="act-btn danger"
-              hx-delete="/api/series/{{ s.path }}"
-              hx-target="closest .series-item"
-              hx-swap="outerHTML"
-              hx-confirm="Remove '{{ s.name }}' from sync? (files stay on disk)">✕</button>
+         class="act-btn muted" style="text-decoration:none;display:inline-flex;align-items:center" title="View on MangaDex">MangaDex ↗</a>
       {% else %}
       <a href="/series?q={{ s.name | urlencode }}" class="act-btn accent"
          style="text-decoration:none;display:inline-flex;align-items:center">Link →</a>
@@ -465,10 +453,6 @@ document.addEventListener('click', (e) => {
 })();
 
 /* ── Series action helpers ───────────────────────────── */
-function _seriesUrl(path, suffix) {
-  return '/api/series/' + path.split('/').map(encodeURIComponent).join('/') + suffix;
-}
-
 function _getLog(btn) {
   return btn.closest('.series-item').querySelector('.series-log');
 }
@@ -514,24 +498,6 @@ function seriesSync(btn) {
       btn.disabled = false;
       btn.textContent = 'Sync';
     });
-}
-
-async function seriesCovers(btn) {
-  const path = btn.dataset.path;
-  const log = _getLog(btn);
-  btn.disabled = true;
-  btn.textContent = '…';
-  try {
-    const resp = await fetch(_seriesUrl(path, '/covers'), {method: 'POST'});
-    const data = await resp.json();
-    log.textContent = data.output || data.error || (data.ok ? 'Done' : 'Failed');
-    log.classList.remove('hidden');
-    btn.textContent = data.ok ? '✓' : '✗';
-    setTimeout(() => { btn.textContent = 'Covers'; btn.disabled = false; }, 3000);
-  } catch(e) {
-    btn.textContent = '✗';
-    setTimeout(() => { btn.textContent = 'Covers'; btn.disabled = false; }, 2000);
-  }
 }
 
 async function refreshSyncButtonStates() {

--- a/web/templates/partials/manga_grab_options.html
+++ b/web/templates/partials/manga_grab_options.html
@@ -1,0 +1,132 @@
+<form id="grab-options-form" hx-put="/api/series/{{ path }}" hx-swap="none"
+      data-series-path="{{ path }}" class="space-y-5">
+  <input type="hidden" name="manga_id" value="{{ manga_id }}">
+  <input type="hidden" name="cover_filename" value="{{ cover_filename }}">
+  <input type="hidden" name="preferred_groups_json" id="preferred-groups-json"
+         value="{{ current_preferred_groups_json|e }}">
+  <input type="hidden" name="language" id="language-hidden" value="{{ current_lang }}">
+  <input type="hidden" name="title" value="{{ folder_name }}">
+  <input type="hidden" name="subfolder" value="{{ subfolder }}">
+  <input type="hidden" name="merge_volumes_override" value="">
+  <input type="hidden" name="exclude_from_fix" value="{{ 'true' if exclude_from_fix else 'false' }}">
+  <input type="hidden" name="mark_sync_configured" value="true">
+
+  <div class="flex items-start justify-between pb-3 gap-3" style="border-bottom:1px solid var(--border)">
+    <div>
+      <h3 class="font-semibold text-sm" style="font-family:'Syne',sans-serif;color:var(--text)">
+        Sync settings — {{ folder_name }}
+      </h3>
+      <p class="text-xs mt-1.5 leading-relaxed" style="color:var(--text-dim)">
+        Choose which language and scanlation groups to download from MangaDex, and where to start.
+      </p>
+    </div>
+    <button type="button"
+            onclick="if (typeof closeModal === 'function') closeModal();"
+            class="text-2xl leading-none transition-colors shrink-0" style="color:var(--text-dim)">&times;</button>
+  </div>
+
+  {% if lang_counts %}
+  <div>
+    <label class="block text-xs font-medium mb-1" style="color:var(--text-muted)">Series language</label>
+    <p class="text-xs mb-2" style="color:var(--text-dim)">Drives ComicInfo <code class="text-[11px]">LanguageISO</code> <em>and</em> the feed language sync uses to fetch new chapters.</p>
+    <div class="flex flex-wrap gap-2">
+      {% for lang, count in lang_counts.items() %}
+      <button type="button"
+              onclick="selectLang(this, '{{ lang }}', '{{ manga_id }}')"
+              data-lang="{{ lang }}"
+              class="lang-btn text-xs px-3 py-1.5 rounded-lg border transition-colors
+                     {% if lang == current_lang %}bg-violet-600 border-violet-600 text-white{% endif %}">
+        {{ lang.upper() }} · {{ count }}
+      </button>
+      {% endfor %}
+    </div>
+  </div>
+  {% else %}
+  <div>
+    <label class="block text-xs font-medium mb-1.5" style="color:var(--text-muted)">Series language</label>
+    <p class="text-xs" style="color:var(--text-dim)">
+      No per-language chapter counts (common for licensed titles). Keeping
+      <strong style="color:var(--text)">{{ current_lang|upper }}</strong>.
+      You can change it later under Edit settings.
+    </p>
+  </div>
+  {% endif %}
+
+  <div>
+    <div class="flex items-center justify-between mb-2">
+      <label class="text-xs font-medium" style="color:var(--text-muted)">Scanlation group priority</label>
+      <span id="selected-group-label" class="text-xs font-medium" style="color:var(--accent-light)"></span>
+    </div>
+    <p class="text-xs mb-1.5" style="color:var(--text-dim)">Drag ⠿ to reorder (first = highest priority). Click a group to move it to the top.</p>
+    <div id="groups-loading" class="hidden text-xs py-2 flex items-center gap-2" style="color:var(--text-muted)">
+      <span class="inline-spinner" aria-hidden="true"></span>
+      Fetching scanlation groups from MangaDex…
+    </div>
+    <div id="group-picker" class="max-h-48 overflow-y-auto space-y-1.5">
+      {% include "partials/group_picker.html" %}
+    </div>
+  </div>
+
+  <div>
+    <label class="block text-xs font-medium mb-1.5" style="color:var(--text-muted)">Start from chapter ≥</label>
+    <p class="text-xs mb-1.5" style="color:var(--text-dim)">First chapter you want sync to download (inclusive). <code class="text-[11px]">0</code> downloads everything. Decimals allowed.</p>
+    <input type="number" name="start_chapter" value="{{ current_start }}" min="0" step="any" inputmode="decimal"
+           class="w-full border rounded-lg px-3 py-2.5 text-sm focus:outline-none">
+  </div>
+
+  <div class="rounded-lg px-3 py-2.5 grid grid-cols-3 gap-x-4 gap-y-1" style="background:var(--surface-alt);border:1px solid var(--border)">
+    {% for code, meaning in [("%1","language"), ("%2","group"), ("%3","title"), ("%4","volume"), ("%5","chapter"), ("%6","ch. title")] %}
+    <div class="flex items-center gap-1.5">
+      <code class="text-xs font-mono" style="color:var(--accent-light)">{{ code }}</code>
+      <span class="text-xs" style="color:var(--text-dim)">{{ meaning }}</span>
+    </div>
+    {% endfor %}
+  </div>
+
+  <div class="flex flex-col gap-2">
+    <button type="submit"
+            class="w-full bg-violet-600 hover:bg-violet-700 text-white text-sm font-semibold py-2.5 rounded-lg transition-colors"
+            style="font-family:'Syne',sans-serif">
+      Save download settings
+    </button>
+    <button type="button"
+            onclick="grabOptionsCancel(this)"
+            class="w-full text-center border text-sm font-medium py-2.5 rounded-lg transition-colors"
+            style="border-color:var(--border-mid);color:var(--text-muted);background:transparent">
+      Cancel
+    </button>
+  </div>
+</form>
+
+<script>
+function _grabOptionsRedirectUrl() {
+  // Reads the raw series path from a data-* attribute (where the browser
+  // unescapes HTML entities for us, unlike a JS string literal rendered by
+  // Jinja autoescape) and percent-encodes each path segment so titles like
+  // "Yotsuba&!" don't get truncated/garbled in the URL.
+  var form = document.getElementById('grab-options-form');
+  var rel = (form && form.dataset && form.dataset.seriesPath) || '';
+  var segs = rel.split('/').filter(Boolean).map(encodeURIComponent).join('/');
+  return '/series/' + segs;
+}
+
+function grabOptionsCancel() {
+  if (typeof closeModal === 'function'
+      && document.getElementById('edit-modal')
+      && !document.getElementById('edit-modal').classList.contains('hidden')) {
+    closeModal();
+    return;
+  }
+  window.location.href = _grabOptionsRedirectUrl();
+}
+
+(function() {
+  var form = document.getElementById('grab-options-form');
+  if (!form || form.dataset.bound === '1') return;
+  form.dataset.bound = '1';
+  form.addEventListener('htmx:afterRequest', function(e) {
+    if (!e.detail || !e.detail.successful) return;
+    window.location.href = _grabOptionsRedirectUrl();
+  });
+})();
+</script>

--- a/web/templates/partials/manga_link_confirm.html
+++ b/web/templates/partials/manga_link_confirm.html
@@ -1,0 +1,76 @@
+<form id="link-confirm-form" class="space-y-5" onsubmit="return false;">
+  <input type="hidden" name="manga_id" value="{{ manga_id }}">
+  <input type="hidden" name="cover_filename" value="{{ cover_filename }}">
+
+  <div class="flex gap-4 pb-4" style="border-bottom:1px solid var(--border)">
+    {% if cover_url %}
+    <img src="{{ cover_url }}" alt="" class="w-16 h-24 object-cover rounded-lg shrink-0 shadow-sm">
+    {% endif %}
+    <div class="min-w-0">
+      <h3 class="font-semibold leading-tight" style="color:var(--text);font-family:'Syne',sans-serif">{{ title }}</h3>
+      <div class="flex items-center gap-2 mt-1.5 flex-wrap">
+        <span class="text-xs px-2 py-0.5 rounded-full font-medium
+          {% if status == 'completed' %}bg-green-100 text-green-700
+          {% elif status == 'ongoing' %}bg-blue-100 text-blue-700
+          {% else %}bg-gray-100 text-gray-600{% endif %}">
+          {{ status }}
+        </span>
+        {% if year %}<span class="text-xs" style="color:var(--text-dim)">{{ year }}</span>{% endif %}
+      </div>
+      {% if available_langs %}
+      <p class="text-xs mt-2" style="color:var(--text-dim)">
+        On MangaDex: {{ available_langs | join(', ') | upper }}
+      </p>
+      {% endif %}
+    </div>
+  </div>
+
+  <p class="text-xs leading-relaxed" style="color:var(--text-muted)">
+    Link this title to get covers and metadata.
+  </p>
+
+  <div>
+    <label class="block text-xs font-medium mb-1.5" style="color:var(--text-muted)">Series language</label>
+    <p class="text-xs mb-1.5" style="color:var(--text-dim)">
+      Sets ComicInfo <code class="text-[11px]">LanguageISO</code> and the feed language used when sync downloads new chapters. Don't pick whatever MangaDex returned first — pick what your files actually are.
+    </p>
+    <select name="language" class="w-full border rounded-lg px-3 py-2.5 text-sm focus:outline-none">
+      {% for code, label in series_language_choices %}
+      <option value="{{ code }}" {% if code == default_lang %}selected{% endif %}>{{ label }}</option>
+      {% endfor %}
+    </select>
+  </div>
+
+  <div>
+    <label class="block text-xs font-medium mb-1.5" style="color:var(--text-muted)">Location</label>
+    <select name="subfolder" class="w-full border rounded-lg px-3 py-2.5 text-sm focus:outline-none">
+      {% if not subdirs %}<option value="">(root)</option>{% endif %}
+      {% for d in subdirs %}
+      <option value="{{ d }}" {% if loop.first %}selected{% endif %}>{{ d }}/</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div>
+    <label class="block text-xs font-medium mb-1.5" style="color:var(--text-muted)">Folder name</label>
+    <input type="text" name="title" required value="{{ title }}"
+           class="w-full border rounded-lg px-3 py-2.5 text-sm focus:outline-none">
+  </div>
+
+  <div class="flex flex-col gap-2">
+    <button type="button"
+            onclick="window.linkMangaFromConfirm && window.linkMangaFromConfirm({ configureDownloads: false })"
+            class="w-full bg-violet-600 hover:bg-violet-700 text-white text-sm font-semibold py-2.5 rounded-lg transition-colors"
+            style="font-family:'Syne',sans-serif">
+      Confirm and done
+    </button>
+    <button type="button"
+            onclick="window.linkMangaFromConfirm && window.linkMangaFromConfirm({ configureDownloads: true })"
+            class="w-full border text-sm font-medium py-2.5 rounded-lg transition-colors"
+            style="border-color:var(--border-mid);color:var(--text-muted)">
+      Confirm and configure downloads
+    </button>
+    <p class="text-xs text-center" style="color:var(--text-dim)">
+      Both options link the manga. Configuring downloads adds language, groups, and chapter cutoff.
+    </p>
+  </div>
+</form>

--- a/web/templates/partials/manga_setup.html
+++ b/web/templates/partials/manga_setup.html
@@ -27,7 +27,8 @@
   <!-- Language picker -->
   {% if lang_counts %}
   <div>
-    <label class="block text-xs font-medium mb-2" style="color:var(--text-muted)">Language</label>
+    <label class="block text-xs font-medium mb-1" style="color:var(--text-muted)">Series language</label>
+    <p class="text-xs mb-2" style="color:var(--text-dim)">Drives ComicInfo <code class="text-[11px]">LanguageISO</code> <em>and</em> the feed language sync uses to fetch new chapters.</p>
     <div class="flex flex-wrap gap-2">
       {% for lang, count in lang_counts.items() %}
       <button type="button"
@@ -49,9 +50,9 @@
       <span id="selected-group-label" class="text-xs font-medium" style="color:var(--accent-light)"></span>
     </div>
     <p class="text-xs mb-1.5" style="color:var(--text-dim)">Drag ⠿ to reorder (first = highest priority). Click a group to move it to the top.</p>
-    <div id="groups-loading" class="hidden text-xs py-1 flex items-center gap-1.5" style="color:var(--text-dim)">
-      <span class="inline-block w-1.5 h-1.5 rounded-full bg-violet-500 animate-pulse"></span>
-      Fetching groups…
+    <div id="groups-loading" class="hidden text-xs py-2 flex items-center gap-2" style="color:var(--text-muted)">
+      <span class="inline-spinner" aria-hidden="true"></span>
+      Fetching scanlation groups from MangaDex…
     </div>
     <div id="group-picker" class="max-h-48 overflow-y-auto space-y-1.5">
       {% include "partials/group_picker.html" %}
@@ -70,8 +71,8 @@
       </select>
     </div>
     <div>
-      <label class="block text-xs font-medium mb-1.5" style="color:var(--text-muted)">Skip chapters ≤</label>
-      <input type="number" name="since" value="0" min="0"
+      <label class="block text-xs font-medium mb-1.5" style="color:var(--text-muted)">Start from chapter ≥</label>
+      <input type="number" name="start_chapter" value="0" min="0" step="any" inputmode="decimal"
              class="w-full border rounded-lg px-3 py-2.5 text-sm focus:outline-none">
     </div>
   </div>

--- a/web/templates/partials/series_edit.html
+++ b/web/templates/partials/series_edit.html
@@ -36,9 +36,9 @@
         Refetch
       </button>
     </div>
-    <div id="groups-loading" class="hidden text-xs py-1.5 mt-1 flex items-center gap-1.5" style="color:var(--text-dim)">
-      <span class="inline-block w-1.5 h-1.5 rounded-full bg-violet-500 animate-pulse"></span>
-      Fetching groups…
+    <div id="groups-loading" class="hidden text-xs py-2 mt-1 flex items-center gap-2" style="color:var(--text-muted)">
+      <span class="inline-spinner" aria-hidden="true"></span>
+      Fetching scanlation groups from MangaDex…
     </div>
     <div id="group-picker" class="mt-2 max-h-40 overflow-y-auto space-y-1.5">
       {% if groups %}
@@ -47,7 +47,7 @@
     </div>
   </div>
 
-  <!-- Location + since -->
+  <!-- Location + start_chapter -->
   <div class="grid grid-cols-2 gap-3">
     <div>
       <label class="block text-xs font-medium mb-1.5" style="color:var(--text-muted)">Location</label>
@@ -59,8 +59,8 @@
       </select>
     </div>
     <div>
-      <label class="block text-xs font-medium mb-1.5" style="color:var(--text-muted)">Skip chapters ≤</label>
-      <input type="number" name="since" value="{{ current_since }}" min="0"
+      <label class="block text-xs font-medium mb-1.5" style="color:var(--text-muted)">Start from chapter ≥</label>
+      <input type="number" name="start_chapter" value="{{ current_start }}" min="0" step="any" inputmode="decimal"
              class="w-full border rounded-lg px-3 py-2.5 text-sm focus:outline-none">
     </div>
   </div>

--- a/web/templates/partials/series_edit_general.html
+++ b/web/templates/partials/series_edit_general.html
@@ -1,0 +1,93 @@
+<form id="series-edit-general-form" hx-put="/api/series/{{ path }}" hx-swap="none" class="space-y-4">
+  <input type="hidden" name="manga_id" value="{{ manga_id }}">
+  <input type="hidden" name="cover_filename" value="{{ current_cover_filename }}">
+  <input type="hidden" name="preferred_groups_json" value="{{ current_preferred_groups_json|e }}">
+  <input type="hidden" name="start_chapter" value="{{ current_start }}">
+  <input type="hidden" name="merge_volumes_override" value="">
+
+  <div class="flex items-center justify-between pb-3" style="border-bottom:1px solid var(--border)">
+    <div>
+      <h2 class="font-semibold" style="font-family:'Syne',sans-serif;color:var(--text)">Edit settings — {{ manga_title }}</h2>
+      <p class="text-xs mt-1" style="color:var(--text-dim)">
+        Location, folder name, series language (ComicInfo + sync feed), and Fix Files. Group priority and chapter cutoff: use Edit sync settings when sync is configured.
+      </p>
+    </div>
+    <button type="button" onclick="closeModal()"
+            class="text-2xl leading-none transition-colors" style="color:var(--text-dim)">&times;</button>
+  </div>
+
+  <div>
+    <label class="block text-xs font-medium mb-1.5" style="color:var(--text-muted)">Location</label>
+    <select name="subfolder" class="w-full border rounded-lg px-3 py-2.5 text-sm focus:outline-none">
+      {% if not subdirs %}<option value="" {% if not subfolder %}selected{% endif %}>(root)</option>{% endif %}
+      {% for d in subdirs %}
+      <option value="{{ d }}" {% if d == subfolder %}selected{% endif %}>{{ d }}/</option>
+      {% endfor %}
+    </select>
+  </div>
+
+  <div>
+    <label class="block text-xs font-medium mb-1.5" style="color:var(--text-muted)">Folder name</label>
+    <input type="text" name="title" required value="{{ folder_name }}"
+           class="w-full border rounded-lg px-3 py-2.5 text-sm focus:outline-none">
+  </div>
+
+  <div>
+    <label class="block text-xs font-medium mb-1.5" style="color:var(--text-muted)">Series language</label>
+    <p class="text-xs mb-1.5" style="color:var(--text-dim)">ComicInfo <code class="text-[11px]">LanguageISO</code> and the feed language sync uses to pull new chapters. Uses ISO-style codes (same as MangaDex).</p>
+    <select name="language" class="w-full border rounded-lg px-3 py-2.5 text-sm focus:outline-none">
+      {% for code, label in series_language_choices %}
+      <option value="{{ code }}" {% if code == current_lang %}selected{% endif %}>{{ label }}</option>
+      {% endfor %}
+    </select>
+  </div>
+
+  <div class="pt-1">
+    <div class="flex items-start justify-between gap-3">
+      <span>
+        <span class="block text-sm font-medium" style="color:var(--text)">Exclude from Fix Files</span>
+        <span class="block text-xs mt-0.5" style="color:var(--text-dim)">
+          When enabled, this series is omitted from Fix Files (naming previews, filename cleanup, duplicates).
+          Sync also skips automatic rename cleanup after downloads for this folder.
+        </span>
+      </span>
+      <button type="button" onclick="toggleEditGeneralExclude(this)"
+              data-on="{{ 'true' if exclude_from_fix else 'false' }}"
+              class="relative inline-flex h-6 w-11 items-center rounded-full transition-colors shrink-0 ml-3"
+              style="{{ 'background:var(--accent)' if exclude_from_fix else 'background:var(--surface-alt)' }}">
+        <span class="inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform
+                     {{ 'translate-x-6' if exclude_from_fix else 'translate-x-1' }}"></span>
+      </button>
+      <input type="hidden" name="exclude_from_fix" id="exclude-from-fix-input"
+             value="{{ 'true' if exclude_from_fix else 'false' }}">
+    </div>
+  </div>
+
+  <button type="submit"
+          class="w-full bg-violet-600 hover:bg-violet-700 text-white text-sm font-semibold py-2.5 rounded-lg transition-colors"
+          style="font-family:'Syne',sans-serif">
+    Save Changes
+  </button>
+</form>
+
+<script>
+function toggleEditGeneralExclude(btn) {
+  const on = btn.dataset.on !== 'true';
+  btn.dataset.on = on ? 'true' : 'false';
+  btn.style.background = on ? 'var(--accent)' : 'var(--surface-alt)';
+  const knob = btn.querySelector('span');
+  knob.classList.toggle('translate-x-6', on);
+  knob.classList.toggle('translate-x-1', !on);
+  document.getElementById('exclude-from-fix-input').value = on ? 'true' : 'false';
+}
+(function() {
+  var form = document.getElementById('series-edit-general-form');
+  if (!form || form.dataset.bound === '1') return;
+  form.dataset.bound = '1';
+  form.addEventListener('htmx:afterRequest', function(e) {
+    if (!e.detail || !e.detail.successful) return;
+    if (typeof closeModal === 'function') closeModal();
+    window.location.reload();
+  });
+})();
+</script>

--- a/web/templates/series.html
+++ b/web/templates/series.html
@@ -2,7 +2,9 @@
 {% block content %}
 <div class="mb-8">
   <h1 class="text-2xl font-bold" style="font-family:'Syne',sans-serif">Add Series</h1>
-  <p class="text-sm mt-1" style="color:var(--text-muted)">Search MangaDex and add a series to sync</p>
+  <p class="text-sm mt-1" style="color:var(--text-muted)">
+    Search MangaDex, link a title for metadata and covers, then optionally set download language and groups.
+  </p>
 </div>
 
 {% if no_root_folders %}
@@ -46,9 +48,11 @@
 
     <!-- Phase 2: setup form (loaded via fetch) -->
     <div id="phase2" class="hidden">
-      <div id="setup-loading" class="flex items-center gap-2 text-xs py-4" style="color:var(--text-dim)">
-        <span class="inline-block w-2 h-2 rounded-full bg-violet-500 animate-pulse"></span>
-        Loading manga details…
+      <div id="setup-loading" class="hidden flex-col items-center justify-center gap-3 py-10">
+        <div class="modal-spinner" role="status" aria-label="Loading"></div>
+        <p id="setup-loading-label" class="text-sm text-center" style="color:var(--text-muted);font-family:'Syne',sans-serif;white-space:pre-line">
+          Loading…
+        </p>
       </div>
       <div id="setup-form"></div>
       <button type="button" onclick="resetToPhase1()"
@@ -61,23 +65,18 @@
 <script>
   const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
 
-  async function loadSetup(mangaId) {
-    document.getElementById('phase1').classList.add('hidden');
-    document.getElementById('phase2').classList.remove('hidden');
-    document.getElementById('setup-loading').classList.remove('hidden');
-    document.getElementById('setup-form').innerHTML = '';
+  function apiSeriesUrl(relPath, suffix) {
+    const segs = relPath.split('/').filter(Boolean).map(encodeURIComponent).join('/');
+    return '/api/series/' + segs + (suffix || '');
+  }
 
-    const resp = await fetch(`/api/manga/${mangaId}/setup`);
-    document.getElementById('setup-loading').classList.add('hidden');
-    document.getElementById('setup-form').innerHTML = await resp.text();
-    htmx.process(document.getElementById('setup-form'));
-
-    // If launched from "Link →", preserve the existing folder name and location
+  function applyFolderSubOverrides(container) {
+    if (!container) return;
     const params = new URLSearchParams(location.search);
     const folder = params.get('folder');
     const sub = params.get('sub');
     if (folder) {
-      const titleInp = document.querySelector('#setup-form [name=title]');
+      const titleInp = container.querySelector('[name=title]');
       if (titleInp) {
         titleInp.value = folder;
         titleInp.readOnly = true;
@@ -85,20 +84,157 @@
       }
     }
     if (sub !== null) {
-      const subSelect = document.querySelector('#setup-form [name=subfolder]');
+      const subSelect = container.querySelector('[name=subfolder]');
       if (subSelect) {
         for (const opt of subSelect.options) {
           if (opt.value === sub) { opt.selected = true; break; }
         }
         subSelect.disabled = true;
         subSelect.style.cssText += ';opacity:.6;cursor:not-allowed';
-        // disabled selects don't submit - add a hidden input to carry the value
         const hidden = document.createElement('input');
         hidden.type = 'hidden';
         hidden.name = 'subfolder';
         hidden.value = sub;
         subSelect.closest('div').appendChild(hidden);
       }
+    }
+  }
+
+  function showSetupLoading(label) {
+    var el = document.getElementById('setup-loading');
+    var lbl = document.getElementById('setup-loading-label');
+    if (lbl) lbl.textContent = label || 'Loading…';
+    if (el) {
+      el.classList.remove('hidden');
+      el.classList.add('flex');
+    }
+  }
+  function hideSetupLoading() {
+    var el = document.getElementById('setup-loading');
+    if (el) {
+      el.classList.add('hidden');
+      el.classList.remove('flex');
+    }
+  }
+
+  async function loadSetup(mangaId) {
+    document.getElementById('phase1').classList.add('hidden');
+    document.getElementById('phase2').classList.remove('hidden');
+    showSetupLoading('Loading manga details…');
+    document.getElementById('setup-form').innerHTML = '';
+
+    const resp = await fetch(`/api/manga/${mangaId}/link-preview`);
+    hideSetupLoading();
+    const html = await resp.text();
+    document.getElementById('setup-form').innerHTML = html;
+    if (!resp.ok) return;
+    htmx.process(document.getElementById('setup-form'));
+
+    applyFolderSubOverrides(document.getElementById('setup-form'));
+  }
+
+  window.loadFullMangaSetup = async function(mangaId) {
+    showSetupLoading('Fetching scanlation groups from MangaDex…\nThis can take a few seconds.');
+    document.getElementById('setup-form').innerHTML = '';
+    try {
+      const resp = await fetch(`/api/manga/${mangaId}/setup`);
+      hideSetupLoading();
+      const html = await resp.text();
+      document.getElementById('setup-form').innerHTML = html;
+      if (!resp.ok) return;
+      htmx.process(document.getElementById('setup-form'));
+      applyFolderSubOverrides(document.getElementById('setup-form'));
+      if (document.getElementById('group-picker-list')) {
+        initGroupOrderUI();
+        syncPreferredGroupsFromPicker();
+      }
+    } catch (e) {
+      hideSetupLoading();
+      throw e;
+    }
+  };
+
+  window.linkMangaFromConfirm = async function(opts) {
+    opts = opts || {};
+    const form = document.getElementById('link-confirm-form');
+    if (!form) return;
+    const fd = new FormData(form);
+    fd.set('preferred_groups_json', '[]');
+    fd.set('start_chapter', '0');
+    fd.set('exclude_from_fix', 'false');
+    fd.set('merge_volumes_override', '');
+    try {
+      const res = await fetch('/api/series', {
+        method: 'POST',
+        body: fd,
+        headers: { 'Accept': 'application/json' },
+      });
+      const raw = await res.text();
+      let data = null;
+      try { data = JSON.parse(raw); } catch (_) {}
+      if (!res.ok) {
+        let msg = res.statusText;
+        if (data) {
+          const d = data.detail;
+          if (typeof d === 'string') msg = d;
+          else if (Array.isArray(d)) msg = d.map(function(x) { return x.msg || JSON.stringify(x); }).join('; ');
+          else if (d) msg = String(d);
+          else if (data.message) msg = data.message;
+        } else if (raw) msg = raw;
+        alert('Could not add series: ' + msg);
+        return;
+      }
+      if (!data || !data.path) {
+        alert('Unexpected response from server');
+        return;
+      }
+      if (opts.configureDownloads) {
+        await loadGrabOptionsAfterLink(data.path);
+      } else {
+        window.location.href = seriesDetailUrl(data.path);
+      }
+    } catch (e) {
+      alert('Could not add series: ' + e);
+    }
+  };
+
+  function seriesDetailUrl(relPath) {
+    // Percent-encode each segment so titles with reserved chars like ``&``
+    // (e.g. ``Yotsuba&!``) don't break the redirect target.
+    var segs = (relPath || '').split('/').filter(Boolean).map(encodeURIComponent).join('/');
+    return '/series/' + segs;
+  }
+
+  async function loadGrabOptionsAfterLink(relPath) {
+    showSetupLoading('Fetching scanlation groups from MangaDex…\nThis can take a few seconds.');
+    document.getElementById('setup-form').innerHTML = '';
+    const url = apiSeriesUrl(relPath, '/grab-options');
+    let resp;
+    try {
+      resp = await fetch(url);
+    } catch (e) {
+      hideSetupLoading();
+      window.location.href = seriesDetailUrl(relPath);
+      return;
+    }
+    hideSetupLoading();
+    if (!resp.ok) {
+      window.location.href = seriesDetailUrl(relPath);
+      return;
+    }
+    document.getElementById('setup-form').innerHTML = await resp.text();
+    htmx.process(document.getElementById('setup-form'));
+    if (document.getElementById('group-picker-list')) {
+      initGroupOrderUI();
+      syncPreferredGroupsFromPicker();
+    }
+    const grabForm = document.getElementById('grab-options-form');
+    if (grabForm) {
+      grabForm.addEventListener('htmx:afterRequest', function handler(e) {
+        if (!e.detail || !e.detail.successful) return;
+        grabForm.removeEventListener('htmx:afterRequest', handler);
+        window.location.href = seriesDetailUrl(relPath);
+      });
     }
   }
 

--- a/web/templates/series_detail.html
+++ b/web/templates/series_detail.html
@@ -92,6 +92,10 @@
       <button type="button" class="detail-act-btn detail-act-btn--accent" onclick="detailSeriesSync(this)" data-path="{{ series.path }}">Sync now</button>
       <button type="button" class="detail-act-btn detail-act-btn--muted" onclick="detailSeriesCovers(this)" data-path="{{ series.path }}">Push Kavita covers</button>
       <button type="button" class="detail-act-btn detail-act-btn--muted" onclick="detailSeriesRegenerateComicInfo(this)" data-path="{{ series.path }}">Regenerate ComicInfo</button>
+      <button type="button" class="detail-act-btn detail-act-btn--warn"
+              onclick="detailSeriesResetSourceMetadata(this)"
+              data-path="{{ series.path }}"
+              title="Drop per-chapter MangaDex metadata for files already on disk. Series-level info (cover, language, status) stays.">Treat files as local</button>
       <a href="https://mangadex.org/title/{{ series.config.id }}" target="_blank" rel="noopener"
          class="detail-act-btn detail-act-btn--muted" title="Open on MangaDex">Open MangaDex ↗</a>
       {% else %}
@@ -103,6 +107,12 @@
               hx-get="/api/series/{{ series.path }}/edit"
               hx-target="#modal-body"
               hx-swap="innerHTML">Edit settings</button>
+      {% if series.linked and series.sync_configured %}
+      <button type="button" class="detail-act-btn detail-act-btn--muted"
+              hx-get="/api/series/{{ series.path }}/grab-options"
+              hx-target="#modal-body"
+              hx-swap="innerHTML">Edit sync settings</button>
+      {% endif %}
       <button type="button" id="btn-detail-remove-series" class="detail-act-btn detail-act-btn--danger ml-auto"
               hx-delete="/api/series/{{ series.path }}"
               hx-swap="none"
@@ -112,30 +122,53 @@
   </div>
 </div>
 
-<div class="grid gap-4 lg:grid-cols-2">
-  <div class="rounded-xl border p-4" style="background:var(--surface);border-color:var(--border)">
-    <h2 class="text-sm font-semibold mb-3" style="font-family:'Syne',sans-serif;color:var(--text)">Series Settings</h2>
-    <div class="space-y-2 text-sm">
-      <div style="color:var(--text-muted)">Language: <span style="color:var(--text)">{{ series.language or "en" }}</span></div>
-      <div style="color:var(--text-muted)">Group priority:
-        <span style="color:var(--text)">
-          {% if series.preferred_groups and series.preferred_groups|length > 0 %}
-            {{ series.preferred_groups | join(' → ') }}
-          {% else %}
-            any
-          {% endif %}
-        </span>
+<div class="grid gap-4 lg:grid-cols-2 items-start">
+  <div class="space-y-4">
+    <div class="rounded-xl border p-4" style="background:var(--surface);border-color:var(--border)">
+      <h2 class="text-sm font-semibold mb-3" style="font-family:'Syne',sans-serif;color:var(--text)">General</h2>
+      <div class="space-y-2 text-sm">
+        <div style="color:var(--text-muted)">Path: <span style="color:var(--text);word-break:break-all">{{ series.path }}</span></div>
+        <div style="color:var(--text-muted)">Linked: <span style="color:var(--text)">{{ "Yes" if series.linked else "No" }}</span></div>
+        <div style="color:var(--text-muted)">Series language: <span style="color:var(--text)">{{ (series.language or "en")|upper }}</span></div>
+        <div style="color:var(--text-muted)">Exclude from Fix Files: <span style="color:var(--text)">{{ "Yes" if series.exclude_from_fix else "No" }}</span></div>
       </div>
-      <div style="color:var(--text-muted)">Skip chapters ≤ <span style="color:var(--text)">{{ series.since or 0 }}</span></div>
-      <div style="color:var(--text-muted)">Exclude from Fix Files: <span style="color:var(--text)">{{ "Yes" if series.exclude_from_fix else "No" }}</span></div>
+    </div>
+
+    <div class="rounded-xl border p-4" style="background:var(--surface);border-color:var(--border)">
+      <h2 class="text-sm font-semibold mb-3" style="font-family:'Syne',sans-serif;color:var(--text)">Sync Settings</h2>
+      {% if not series.linked %}
+        <p class="text-sm" style="color:var(--text-dim)">
+          Not linked to MangaDex. Link to enable sync.
+        </p>
+      {% elif not series.sync_configured %}
+        <div class="flex items-center justify-between gap-3 text-sm">
+          <span style="color:var(--text-dim)">Sync not configured</span>
+          <button type="button" class="detail-act-btn detail-act-btn--accent text-xs"
+                  hx-get="/api/series/{{ series.path }}/grab-options"
+                  hx-target="#modal-body"
+                  hx-swap="innerHTML">Configure downloads</button>
+        </div>
+      {% else %}
+        <div class="space-y-2 text-sm">
+          <div style="color:var(--text-muted)">Language: <span style="color:var(--text)">{{ series.language or "en" }}</span></div>
+          <div style="color:var(--text-muted)">Group priority:
+            <span style="color:var(--text)">
+              {% if series.preferred_groups and series.preferred_groups|length > 0 %}
+                {{ series.preferred_groups | join(' → ') }}
+              {% else %}
+                any
+              {% endif %}
+            </span>
+          </div>
+          <div style="color:var(--text-muted)">Start from chapter ≥ <span style="color:var(--text)">{{ series.start_chapter or 0 }}</span></div>
+        </div>
+      {% endif %}
     </div>
   </div>
 
   <div class="rounded-xl border p-4" style="background:var(--surface);border-color:var(--border)">
     <h2 class="text-sm font-semibold mb-3" style="font-family:'Syne',sans-serif;color:var(--text)">Metadata</h2>
     <div class="space-y-2 text-sm">
-      <div style="color:var(--text-muted)">Path: <span style="color:var(--text)">{{ series.path }}</span></div>
-      <div style="color:var(--text-muted)">Linked: <span style="color:var(--text)">{{ "Yes" if series.linked else "No" }}</span></div>
       {% if series.linked %}
       <div style="color:var(--text-muted)">Status: <span style="color:var(--text)">{{ series.config.status or "unknown" }}</span></div>
       <div class="pt-1 space-y-2">
@@ -282,7 +315,7 @@
     <h2 class="text-base font-semibold" style="font-family:'Syne',sans-serif;color:var(--text)">Edit ComicInfo</h2>
     <p id="comicinfo-modal-file" class="text-xs mt-1" style="color:var(--text-dim)"></p>
     <div class="grid grid-cols-2 gap-3 mt-4">
-      {% for f in ["Series","Number","Volume","Title","Summary","Writer","Penciller","Publisher","Genre","Count","Web","LanguageISO","Year","Manga","AgeRating","PageCount"] %}
+      {% for f in ["Series","Number","Volume","Title","Summary","Writer","Penciller","Translator","Publisher","Genre","Count","Web","LanguageISO","Year","Manga","AgeRating","PageCount"] %}
       <label class="{{ 'col-span-2' if f in ['Summary','Genre'] else '' }}">
         <span class="block text-[11px] mb-1" style="color:var(--text-muted)">{{ f }}</span>
         {% if f == "Summary" %}
@@ -405,6 +438,66 @@ async function detailSeriesCovers(btn) {
     log.classList.remove('hidden');
     btn.textContent = '✗';
     setTimeout(function() { btn.textContent = 'Kavita covers'; btn.disabled = false; }, 2000);
+  }
+}
+
+async function detailSeriesResetSourceMetadata(btn) {
+  var path = btn.dataset.path;
+  var log = document.getElementById('detail-action-log');
+  var ok = await window.appConfirm(
+    'Drop per-chapter source metadata (title, scanlator, chapter URL, language) for every file on disk in this series? '
+    + 'Files stay on disk, the series stays linked, and series-level info (cover, language, status) is unchanged. '
+    + 'ComicInfo will be regenerated using series-level data only.'
+  );
+  if (!ok) return;
+  btn.disabled = true;
+  btn.textContent = '…';
+  log.textContent = '';
+  log.classList.remove('hidden');
+  try {
+    var resp = await fetch(seriesDetailApiUrl(path, '/reset-source-metadata'), { method: 'POST' });
+    var data = await resp.json();
+    if (!resp.ok || !data.ok) throw new Error(data.detail || data.error || 'Reset failed');
+    log.textContent = 'Detached source metadata from ' + (data.reset || 0) + ' chapter row(s). Regenerating ComicInfo…';
+    var regenResp = await fetch('/api/jobs/regenerate-comicinfo/' + path.split('/').map(encodeURIComponent).join('/'), { method: 'POST' });
+    var regenData = await regenResp.json();
+    if (!regenResp.ok || !regenData.ok || !regenData.job) {
+      log.textContent += '\n(could not enqueue ComicInfo regeneration: ' + (regenData.error || 'unknown') + ')';
+      btn.textContent = '✓';
+      setTimeout(function() { btn.textContent = 'Treat files as local'; btn.disabled = false; }, 2000);
+      return;
+    }
+    var es = new EventSource('/api/jobs/' + regenData.job.id + '/stream?from_seq=0');
+    es.onmessage = function(e) {
+      var payload = null;
+      try { payload = JSON.parse(e.data); } catch (err) {}
+      if (!payload) return;
+      if (payload.type === 'line') {
+        var line = document.createElement('div');
+        line.textContent = payload.line || '';
+        log.appendChild(line);
+        log.scrollTop = log.scrollHeight;
+        return;
+      }
+      if (payload.type === 'status') {
+        if (payload.status === 'queued') btn.textContent = 'Queued';
+        if (payload.status === 'running') btn.textContent = 'Running';
+        if (payload.status === 'completed' || payload.status === 'failed' || payload.status === 'cancelled' || payload.status === 'missing') {
+          es.close();
+          btn.textContent = payload.status === 'completed' ? '✓' : '✗';
+          setTimeout(function() { btn.textContent = 'Treat files as local'; btn.disabled = false; }, 1800);
+        }
+      }
+    };
+    es.onerror = function() {
+      es.close();
+      btn.textContent = '✗';
+      setTimeout(function() { btn.textContent = 'Treat files as local'; btn.disabled = false; }, 2200);
+    };
+  } catch (e) {
+    log.textContent = String(e);
+    btn.textContent = '✗';
+    setTimeout(function() { btn.textContent = 'Treat files as local'; btn.disabled = false; }, 2200);
   }
 }
 


### PR DESCRIPTION
## Summary

Series-level metadata is now the source of truth for `ComicInfo.xml` on local files; MangaDex per-chapter feeds no longer pollute on-disk content that wasn't actually downloaded by the sync. Plus a pile of related UX cleanup.

### Provenance / language fix
- New `chapters.status` column: `known` / `downloaded` / `on_disk`. Disk scans tag user files as `on_disk`; sync-driven downloads flip them to `downloaded`.
- `_ensure_comicinfo_all` skips chapter title, group, and Web link for `on_disk` rows and always honours the series-level language instead of the per-chapter feed language.
- Unlinking a series and the new **Treat files as local** action on the detail page both call `reset_chapter_source_metadata` to wipe MangaDex-specific fields.
- "Library language" → "Series language" everywhere, surfaced on the link-confirm step with an English-first default and "available on MangaDex" hints.

### Start-chapter semantics
- Rename `series.since` → `series.start_chapter` with a migration (`skip ≤ N` becomes `start ≥ N+1`, and `104.2` becomes `105`).
- Flip the download SQL from `>` to `>=`.
- Allow decimal input (`step="any"` / `inputmode="decimal"`); field is relabeled "Start from chapter ≥".

### UX polish
- Immediate modal spinner on slow HTMX fetches (groups, manga setup) with context-specific labels; inline spinners for group reloads; visible fetch-error states instead of silent spinning.
- Fix the post-save redirect for series whose paths contain `&` — paths now flow through a `data-series-path` attribute and are encoded segment-by-segment client-side.
- Dashboard per-series actions trimmed to Sync / Details / MangaDex (or Link); covers and unlink moved to the detail page.

## Test plan
- [ ] Existing series with `since=104.2` → migrates to `start_chapter=105`, next sync fetches 105+.
- [ ] On-disk-only series shows series language (e.g. `en`) in `ComicInfo.xml`, not the MangaDex feed language.
- [ ] Linking a fresh series defaults the language to `en` when available; selector lists other languages with "· on MangaDex" annotation.
- [ ] Editing sync options for a series with `&` in the title saves and redirects without a "Series not found" page.
- [ ] Opening the edit-sync modal shows a spinner immediately while groups load; switching language refreshes the group list with an inline spinner.
- [ ] **Treat files as local** on the detail page wipes chapter `source`/`title`/`group_name`/`language` and re-runs ComicInfo regen.