### PR TITLE
Add configurable archive permission mask to keep synced files readable.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apk add --no-cache su-exec tzdata && \
     pip install --no-cache-dir fastapi uvicorn jinja2 python-multipart
 
 COPY entrypoint.sh /entrypoint.sh
-COPY manga-fix.py manga-sync.py manga-fix.sh sync_config.py kavita.py db.py comicinfo.py comicinfo_defs.py cron_enqueue_sync.py /app/
+COPY manga-fix.py manga-sync.py manga-fix.sh sync_config.py kavita.py db.py comicinfo.py comicinfo_defs.py cron_enqueue_sync.py file_permissions.py /app/
 COPY web/ /app/web/
 
 RUN chmod +x /entrypoint.sh && mkdir -p /data/config /data/logs

--- a/comicinfo.py
+++ b/comicinfo.py
@@ -4,6 +4,7 @@ import shutil
 import tempfile
 import xml.etree.ElementTree as ET
 import zipfile
+from file_permissions import apply_file_permission_mask
 
 _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".gif", ".avif"}
 
@@ -108,7 +109,12 @@ def count_pages(cbz_path: str) -> int:
         return 0
 
 
-def inject_comicinfo(cbz_path: str, xml_content: str, overwrite: bool = False) -> bool:
+def inject_comicinfo(
+    cbz_path: str,
+    xml_content: str,
+    overwrite: bool = False,
+    file_permission_mask: str | None = None,
+) -> bool:
     """Add or replace ComicInfo.xml inside a CBZ. Returns True on success."""
     if not os.path.exists(cbz_path):
         return False
@@ -133,6 +139,7 @@ def inject_comicinfo(cbz_path: str, xml_content: str, overwrite: bool = False) -
                 zout.writestr("ComicInfo.xml", xml_content.encode("utf-8"))
 
         shutil.move(tmp_path, cbz_path)
+        apply_file_permission_mask(cbz_path, file_permission_mask)
         return True
     except Exception:
         if tmp_path and os.path.exists(tmp_path):
@@ -145,6 +152,7 @@ def merge_chapters_into_volume(
     output_path: str,
     comicinfo_xml: str = None,
     cover_image_bytes: bytes = None,
+    file_permission_mask: str | None = None,
 ) -> bool:
     """Merge sorted chapter CBZs into a single volume CBZ. Returns True on success.
 
@@ -177,6 +185,7 @@ def merge_chapters_into_volume(
                 zout.writestr("ComicInfo.xml", comicinfo_xml.encode("utf-8"))
 
         shutil.move(tmp_path, output_path)
+        apply_file_permission_mask(output_path, file_permission_mask)
         return True
     except Exception:
         if tmp_path and os.path.exists(tmp_path):

--- a/file_permissions.py
+++ b/file_permissions.py
@@ -1,0 +1,32 @@
+"""Helpers for validating and applying file permission masks."""
+
+import os
+import re
+
+_PERM_MASK_RE = re.compile(r"^[0-7]{3,4}$")
+
+
+def sanitize_file_permission_mask(mask: str | None, default: str = "664") -> str:
+    """Return a normalized octal permission mask string (e.g. ``664``)."""
+    raw = str(mask or "").strip()
+    if not raw:
+        return default
+    if raw.startswith("0o"):
+        raw = raw[2:]
+    elif raw.startswith("0") and len(raw) > 3:
+        raw = raw[1:]
+    if not _PERM_MASK_RE.fullmatch(raw):
+        return default
+    return raw[-3:]
+
+
+def parse_file_permission_mask(mask: str | None, default: str = "664") -> int:
+    """Parse a mask string into an int suitable for ``os.chmod``."""
+    return int(sanitize_file_permission_mask(mask, default=default), 8)
+
+
+def apply_file_permission_mask(path: str, mask: str | None, default: str = "664") -> None:
+    """Apply a sanitized permission mask to ``path`` if it exists."""
+    if not os.path.exists(path):
+        return
+    os.chmod(path, parse_file_permission_mask(mask, default=default))

--- a/manga-sync.py
+++ b/manga-sync.py
@@ -51,6 +51,7 @@ from comicinfo import (                                 # noqa: E402
 )
 from sync_config import load_settings, sanitize_volume_naming  # noqa: E402
 from kavita import KavitaClient                        # noqa: E402
+from file_permissions import apply_file_permission_mask # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -560,7 +561,7 @@ def normalize_volume_filenames_for_kavita(series_row: dict, conn) -> int:
     return n
 
 
-def refresh_volume_comicinfo_embeds(series_row: dict, conn) -> int:
+def refresh_volume_comicinfo_embeds(series_row: dict, conn, settings: dict | None = None) -> int:
     """Rewrite ComicInfo in volume CBZs (fixes Kavita showing Number == volume)."""
     series_id   = series_row["id"]
     series_path = series_row["path"]
@@ -573,6 +574,7 @@ def refresh_volume_comicinfo_embeds(series_row: dict, conn) -> int:
     series_title = (meta or {}).get("title") or os.path.basename(series_dir)
     label       = series_row.get("name", series_path)
 
+    file_permission_mask = (settings or {}).get("file_permission_mask")
     rows = conn.execute(
         "SELECT * FROM volumes WHERE series_id=? AND path IS NOT NULL",
         (series_id,),
@@ -609,7 +611,12 @@ def refresh_volume_comicinfo_embeds(series_row: dict, conn) -> int:
             series_web=series_web,
             page_count=count_pages(cbz_path),
         )
-        if inject_comicinfo(cbz_path, xml, overwrite=True):
+        if inject_comicinfo(
+            cbz_path,
+            xml,
+            overwrite=True,
+            file_permission_mask=file_permission_mask,
+        ):
             mark_volume_comicinfo(conn, vol["id"])
             done += 1
     _log(f"[{label}] refreshed ComicInfo in {done} volume file(s) (Kavita-friendly)")
@@ -706,7 +713,13 @@ def _merge_volume_batch(
              f"({len(ch_paths)} ch) → {out_name}"
              + (" [+cover]" if cover_bytes else ""))
 
-        if merge_chapters_into_volume(ch_paths, out_path, xml, cover_bytes):
+        if merge_chapters_into_volume(
+            ch_paths,
+            out_path,
+            xml,
+            cover_bytes,
+            file_permission_mask=settings.get("file_permission_mask"),
+        ):
             rel_out  = os.path.relpath(out_path, MANGA_ROOT)
             vol_id   = vol_row["id"]
             mark_volume_merged(conn, vol_id, rel_out, os.path.getsize(out_path))
@@ -791,6 +804,7 @@ def _ensure_comicinfo_all(
     series_web: str | None = None,
     series_label: str | None = None,
     force_overwrite: bool = False,
+    file_permission_mask: str | None = None,
 ):
     ch_rows, vol_rows = get_files_missing_comicinfo(conn, series_id)
     if not ch_rows and not vol_rows:
@@ -853,7 +867,12 @@ def _ensure_comicinfo_all(
             page_count=count_pages(cbz_path),
             web=ch_web,
         )
-        if inject_comicinfo(cbz_path, xml, overwrite=True):
+        if inject_comicinfo(
+            cbz_path,
+            xml,
+            overwrite=True,
+            file_permission_mask=file_permission_mask,
+        ):
             mark_chapter_comicinfo(conn, ch["id"])
             injected_ch += 1
             _log(f"[{label}] ComicInfo {idx}/{total_ch}: {os.path.basename(cbz_path)}")
@@ -887,7 +906,12 @@ def _ensure_comicinfo_all(
             series_web=series_web,
             page_count=count_pages(cbz_path),
         )
-        if inject_comicinfo(cbz_path, xml, overwrite=True):
+        if inject_comicinfo(
+            cbz_path,
+            xml,
+            overwrite=True,
+            file_permission_mask=file_permission_mask,
+        ):
             mark_volume_comicinfo(conn, vol["id"])
             injected_vol += 1
             _log(f"[{label}] ComicInfo vol {idx}/{total_vol}: {os.path.basename(cbz_path)}")
@@ -963,6 +987,7 @@ def _sync_one_series(
     source_name = series_row.get("source_name") or "mangadex"
     name        = series_row.get("name") or os.path.basename(series_path)
     series_web  = f"https://mangadex.org/title/{manga_id}" if manga_id else None
+    file_permission_mask = settings.get("file_permission_mask")
     _log(f"[{name}] checking for updates…")
 
     # Always reconcile disk state first
@@ -980,6 +1005,7 @@ def _sync_one_series(
         _ensure_comicinfo_all(
             series_id, series_dir, conn, meta, language,
             series_web=series_web, series_label=name,
+            file_permission_mask=file_permission_mask,
         )
         update_source_sync_time(conn, series_id, source_name)
         return False
@@ -997,7 +1023,8 @@ def _sync_one_series(
         _log(f"[{name}] up-to-date")
         _ensure_comicinfo_all(
             series_id, series_dir, conn, meta, language,
-            series_web=series_web, series_label=name
+            series_web=series_web, series_label=name,
+            file_permission_mask=file_permission_mask,
         )
         return False
 
@@ -1053,6 +1080,7 @@ def _sync_one_series(
                                 os.remove(fpath)
                             fpath = desired_path
                 rel = os.path.relpath(fpath, MANGA_ROOT)
+                apply_file_permission_mask(fpath, file_permission_mask)
                 mark_chapter_downloaded(conn, ch_row["id"], rel,
                                         os.path.getsize(fpath))
                 downloaded += 1
@@ -1082,7 +1110,8 @@ def _sync_one_series(
     # ComicInfo injection for all remaining files
     _ensure_comicinfo_all(
         series_id, series_dir, conn, meta, language,
-        series_web=series_web, series_label=name
+        series_web=series_web, series_label=name,
+        file_permission_mask=file_permission_mask,
     )
 
     # Kavita covers
@@ -1180,7 +1209,7 @@ def main(
             _log(f"[comicinfo-refresh] unknown series: {rel_path}")
             conn.close()
             return
-        refresh_volume_comicinfo_embeds(row, conn)
+        refresh_volume_comicinfo_embeds(row, conn, settings=settings)
         conn.close()
         return
 
@@ -1245,6 +1274,7 @@ def main(
             series_web=(f"https://mangadex.org/title/{row['source_id']}" if row.get("source_id") else None),
             series_label=row.get("name", row["path"]),
             force_overwrite=True,
+            file_permission_mask=settings.get("file_permission_mask"),
         )
         _log("[comicinfo-regenerate] done")
         conn.close()
@@ -1269,6 +1299,7 @@ def main(
                 series_row.get("language", "en"),
                 series_web=None,
                 series_label=series_name,
+                file_permission_mask=settings.get("file_permission_mask"),
             )
             continue
 

--- a/sync_config.py
+++ b/sync_config.py
@@ -1,5 +1,6 @@
 import os
 import re
+from file_permissions import sanitize_file_permission_mask
 
 # Settings are stored in SQLite (``app_config`` table under ``DATA_DIR/db/``).
 # ``CONFIG_PATH`` env still selects a legacy ``settings.json`` for one-time import
@@ -18,6 +19,7 @@ DEFAULTS = {
     "auto_scan":       False,
     "kavita_url":      "",
     "kavita_api_key":  "",
+    "file_permission_mask": "664",
 }
 
 
@@ -65,6 +67,7 @@ def load_settings() -> dict:
     out.pop("merge_volume_naming", None)
     out["volume_naming"] = sanitize_volume_naming(out.get("volume_naming"))
     out["sync_cron"] = sanitize_sync_cron(out.get("sync_cron"))
+    out["file_permission_mask"] = sanitize_file_permission_mask(out.get("file_permission_mask"))
     return out
 
 
@@ -84,6 +87,7 @@ def save_settings(data: dict):
         merged.pop("merge_volume_naming", None)
         merged["volume_naming"] = sanitize_volume_naming(merged.get("volume_naming"))
         merged["sync_cron"] = sanitize_sync_cron(merged.get("sync_cron"))
+        merged["file_permission_mask"] = sanitize_file_permission_mask(merged.get("file_permission_mask"))
         write_stored_settings(conn, merged)
     finally:
         conn.close()

--- a/tests/test_sync_config.py
+++ b/tests/test_sync_config.py
@@ -1,6 +1,7 @@
 import json
 
 import db
+import file_permissions
 import sync_config
 
 
@@ -59,6 +60,14 @@ def test_second_save_preserves_first(tmp_path, monkeypatch):
 def test_default_naming_matches_mdx():
     assert sync_config.DEFAULTS["chapter_naming"] == "[%1 %2] %3 vol.%4 ch.%5"
     assert sync_config.DEFAULTS["volume_naming"] == "[%1 %2] %3 vol.%4"
+    assert sync_config.DEFAULTS["file_permission_mask"] == "664"
+
+
+def test_sanitize_file_permission_mask():
+    assert file_permissions.sanitize_file_permission_mask("775") == "775"
+    assert file_permissions.sanitize_file_permission_mask("0775") == "775"
+    assert file_permissions.sanitize_file_permission_mask("0o755") == "755"
+    assert file_permissions.sanitize_file_permission_mask("999") == "664"
 
 
 def test_sanitize_volume_naming_removes_chapter_placeholders():

--- a/web/app.py
+++ b/web/app.py
@@ -109,6 +109,7 @@ from comicinfo import (                                # noqa: E402
     inject_comicinfo,
 )
 from comicinfo_defs import MANGA_VALUES, AGE_RATING_VALUES  # noqa: E402
+from file_permissions import sanitize_file_permission_mask   # noqa: E402
 
 app = FastAPI(title="Manga Maid")
 templates = Jinja2Templates(directory="/app/web/templates")
@@ -1094,6 +1095,7 @@ async def save_settings_endpoint(
     auto_covers:       str = Form("false"),
     kavita_url:        str = Form(""),
     kavita_api_key:    str = Form(""),
+    file_permission_mask: str = Form("664"),
 ):
     try:
         root_folders = json.loads(root_folders_json)
@@ -1120,6 +1122,7 @@ async def save_settings_endpoint(
         "auto_covers":    auto_covers == "true",
         "kavita_url":     kavita_url.strip(),
         "kavita_api_key": kavita_api_key.strip(),
+        "file_permission_mask": sanitize_file_permission_mask(file_permission_mask),
     })
     if sanitize_sync_cron(before.get("sync_cron")) != normalized_sync_cron:
         try:
@@ -2145,7 +2148,12 @@ async def update_chapter_comicinfo(path: str, chapter_id: int, body: ComicInfoUp
         fields["Series"] = row.get("name") or row.get("title") or ""
     _validate_comicinfo_fields(fields)
     xml = _comicinfo_fields_to_xml(fields)
-    ok = inject_comicinfo(abs_f, xml, overwrite=True)
+    ok = inject_comicinfo(
+        abs_f,
+        xml,
+        overwrite=True,
+        file_permission_mask=load_settings().get("file_permission_mask"),
+    )
     if not ok:
         raise HTTPException(500, "Could not write ComicInfo.xml")
     _db.mark_chapter_comicinfo(conn, int(r["id"]))
@@ -2207,7 +2215,12 @@ async def update_volume_comicinfo(path: str, volume_id: int, body: ComicInfoUpda
         fields["Series"] = row.get("name") or row.get("title") or ""
     _validate_comicinfo_fields(fields)
     xml = _comicinfo_fields_to_xml(fields)
-    ok = inject_comicinfo(abs_f, xml, overwrite=True)
+    ok = inject_comicinfo(
+        abs_f,
+        xml,
+        overwrite=True,
+        file_permission_mask=load_settings().get("file_permission_mask"),
+    )
     if not ok:
         raise HTTPException(500, "Could not write ComicInfo.xml")
     _db.mark_volume_comicinfo(conn, int(r["id"]))

--- a/web/templates/settings.html
+++ b/web/templates/settings.html
@@ -70,6 +70,15 @@
                class="w-full border rounded-lg px-3 py-2.5 text-sm focus:outline-none">
       </div>
     </div>
+    <div>
+      <label class="block text-xs font-medium mb-1.5" style="color:var(--text-muted)">File permission mask</label>
+      <input type="text" name="file_permission_mask" value="{{ settings.file_permission_mask }}"
+             pattern="[0-7]{3,4}" maxlength="4" placeholder="664"
+             class="w-full border rounded-lg px-3 py-2.5 text-sm font-mono focus:outline-none">
+      <p class="text-xs mt-1.5" style="color:var(--text-dim)">
+        Applied after downloads, merges, and ComicInfo writes. Use octal masks like 664, 755, or 777.
+      </p>
+    </div>
     <div class="space-y-2">
       <label class="block text-xs font-medium" style="color:var(--text-muted)">Auto-sync schedule</label>
       <select id="sync-cron-preset" class="w-full border rounded-lg px-3 py-2.5 text-sm focus:outline-none">


### PR DESCRIPTION
This applies a sanitized chmod mask after downloads, merges, and ComicInfo rewrites, and exposes the mask in settings so deployments can match their filesystem/user model.