### PR TITLE
Root folder gating, Kavita UA, jobs/fix UI, disable auto volume merge

### DIFF
--- a/cron_enqueue_sync.py
+++ b/cron_enqueue_sync.py
@@ -8,6 +8,12 @@ import db
 def main() -> int:
     data_dir = os.environ.get("DATA_DIR", "/data")
     conn = db.init_db(data_dir)
+    stored = db.read_stored_settings(conn)
+    roots = [rf for rf in (stored.get("root_folders") or []) if rf is not None]
+    if not roots:
+        print("[cron] no root folders configured; skipping sync_all enqueue")
+        conn.close()
+        return 0
     # Avoid stacking duplicate global sync jobs.
     exists = conn.execute(
         """

--- a/db.py
+++ b/db.py
@@ -477,8 +477,33 @@ def migrate_json_configs(manga_root: str, conn: sqlite3.Connection) -> int:
     return imported
 
 
-def scan_disk_series(manga_root: str, conn: sqlite3.Connection) -> int:
-    """Find dirs with manga files but no DB entry; add as unlinked series."""
+def scan_disk_series(
+    manga_root: str,
+    conn: sqlite3.Connection,
+    allowed_roots: list[str] | None = None,
+) -> int:
+    """Find dirs with manga files but no DB entry; add as unlinked series.
+
+    If ``allowed_roots`` is a list (including empty), only paths under those
+    roots are considered; an empty list discovers nothing. If ``None``, the
+    whole tree under ``manga_root`` is scanned (legacy callers / tests).
+    """
+    unrestricted = allowed_roots is None
+    roots: list[str] = []
+    if not unrestricted:
+        for rf in allowed_roots:
+            s = str(rf or "").strip().strip("/")
+            if s and s not in roots:
+                roots.append(s)
+
+    def _is_allowed(rel_path: str) -> bool:
+        if unrestricted:
+            return True
+        if not roots:
+            return False
+        p = rel_path.replace("\\", "/").strip()
+        return any(p == r or p.startswith(r + "/") for r in roots)
+
     added = 0
     now = _now()
     for root, dirs, files in os.walk(manga_root):
@@ -487,6 +512,8 @@ def scan_disk_series(manga_root: str, conn: sqlite3.Connection) -> int:
         if not has_manga:
             continue
         rel_path = os.path.relpath(root, manga_root)
+        if not _is_allowed(rel_path):
+            continue
         if conn.execute("SELECT 1 FROM series WHERE path=?", (rel_path,)).fetchone():
             dirs.clear()
             continue

--- a/kavita.py
+++ b/kavita.py
@@ -3,6 +3,11 @@ import json
 from urllib import error as urlerror
 from urllib import parse, request as urlrequest
 
+KAVITA_USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+)
+
 
 class KavitaClient:
     def __init__(self, base_url: str, api_key: str):
@@ -17,6 +22,7 @@ class KavitaClient:
         })
         req = urlrequest.Request(url, method="POST")
         req.add_header("Content-Length", "0")
+        req.add_header("User-Agent", KAVITA_USER_AGENT)
         with urlrequest.urlopen(req, timeout=15) as resp:
             data = json.loads(resp.read())
         self._token = data["token"]
@@ -29,6 +35,7 @@ class KavitaClient:
             url += "?" + parse.urlencode(params)
         data = json.dumps(body).encode() if body is not None else None
         req = urlrequest.Request(url, data=data, method=method)
+        req.add_header("User-Agent", KAVITA_USER_AGENT)
         req.add_header("Authorization", f"Bearer {self._token}")
         if data:
             req.add_header("Content-Type", "application/json")

--- a/manga-sync.py
+++ b/manga-sync.py
@@ -1091,10 +1091,9 @@ def _sync_one_series(
 
         time.sleep(delay)
 
-    merge_ok = bool(settings.get("merge_volumes", True))
-    ov = series_row.get("merge_volumes_override")
-    if ov is not None:
-        merge_ok = bool(ov)
+    # Legacy UI-level "compact into volume" toggles are intentionally ignored.
+    # Volume merge should only run via explicit compact mode CLI path.
+    merge_ok = False
 
     # Filename cleanup (skip series excluded from Fix Files / manual filenames)
     if not series_row.get("exclude_from_fix"):
@@ -1139,13 +1138,13 @@ def main(
 
     conn = init_db(DATA_DIR)
     migrated = migrate_json_configs(MANGA_ROOT, conn)
-    added    = scan_disk_series(MANGA_ROOT, conn)
+    settings = load_settings()
+    roots = [rf for rf in (settings.get("root_folders") or []) if rf is not None]
+    added = scan_disk_series(MANGA_ROOT, conn, allowed_roots=roots)
     if migrated:
         _log(f"[startup] migrated {migrated} .mangadex.json config(s) to DB")
     if added:
         _log(f"[startup] catalogued {added} unlinked series from disk")
-
-    settings = load_settings()
 
     kavita_client = None
     kurl = settings.get("kavita_url", "").strip()
@@ -1158,6 +1157,13 @@ def main(
         series_list = [s for s in [get_series_by_path(conn, rel_path)] if s]
     else:
         series_list = get_all_series(conn)
+        if roots:
+            filtered: list[dict] = []
+            for s in series_list:
+                p = (s.get("path") or "").replace("\\", "/").strip()
+                if any(p == rf or p.startswith(rf + "/") for rf in roots):
+                    filtered.append(s)
+            series_list = filtered
 
     if covers_only:
         for s in series_list:

--- a/sync_config.py
+++ b/sync_config.py
@@ -14,7 +14,7 @@ DEFAULTS = {
     "volume_naming":   "[%1 %2] %3 vol.%4",
     "download_delay":  1.0,
     "sync_cron":       "0 */6 * * *",
-    "merge_volumes":   True,
+    "merge_volumes":   False,
     "auto_covers":     False,
     "auto_scan":       False,
     "kavita_url":      "",

--- a/web/app.py
+++ b/web/app.py
@@ -140,7 +140,8 @@ def _get_conn():
     if _conn is None:
         _conn = _db.init_db(DATA_DIR)
         _db.migrate_json_configs(MANGA_ROOT, _conn)
-        _db.scan_disk_series(MANGA_ROOT, _conn)
+        roots = [rf for rf in (load_settings().get("root_folders") or []) if rf is not None]
+        _db.scan_disk_series(MANGA_ROOT, _conn, allowed_roots=roots)
     return _conn
 
 
@@ -154,6 +155,9 @@ def _write_runtime_crontab(cron_expr: str) -> None:
 
 
 def _enqueue_reconcile_job(reason: str) -> int | None:
+    roots = [rf for rf in (load_settings().get("root_folders") or []) if rf is not None]
+    if not roots:
+        return None
     conn = _get_conn()
     active = _db.get_active_jobs(conn, queue_key=JOB_QUEUE_KEY)
     for j in active:
@@ -173,10 +177,14 @@ def _run_disk_reconcile(job_id: int, payload: dict | None = None) -> None:
     reason = str(payload.get("reason") or "manual").strip()
     _db.append_job_log(conn, job_id, f"[reconcile] started (reason: {reason})")
 
-    added = _db.scan_disk_series(MANGA_ROOT, conn)
-    _db.append_job_log(conn, job_id, f"[reconcile] discovered {added} new series")
-
     roots = [rf for rf in (load_settings().get("root_folders") or []) if rf is not None]
+    if not roots:
+        _db.append_job_log(conn, job_id, "[reconcile] skipped — no root folders configured")
+        _db.append_job_log(conn, job_id, "[reconcile] done")
+        return
+
+    added = _db.scan_disk_series(MANGA_ROOT, conn, allowed_roots=roots)
+    _db.append_job_log(conn, job_id, f"[reconcile] discovered {added} new series")
     series_rows = _db.get_all_series(conn)
     scanned = 0
     for row in series_rows:
@@ -477,13 +485,17 @@ def _resolve_total_volumes(attr: dict | None, manga_id: str) -> int:
     return _mdex_tankobon_volume_count_from_aggregate(agg)
 
 
-def _scan_settings_naming_issues() -> list[tuple[str, str, str]]:
+def _scan_settings_naming_issues(series_path: str | None = None) -> list[tuple[str, str, str]]:
     settings = load_settings()
     chapter_tpl = settings.get("chapter_naming", "%3 ch.%5")
     volume_tpl = settings.get("volume_naming", "%3 vol.%4")
     conn = _get_conn()
+    series_scope = (series_path or "").strip()
     findings: list[tuple[str, str, str]] = []
-    for series in _db.get_all_series(conn):
+    series_rows = _db.get_all_series(conn)
+    if series_scope:
+        series_rows = [s for s in series_rows if (s.get("path") or "") == series_scope]
+    for series in series_rows:
         _db.scan_disk_files(os.path.join(MANGA_ROOT, series["path"]), series["id"], conn)
 
     volume_ranges = {
@@ -496,7 +508,7 @@ def _scan_settings_naming_issues() -> list[tuple[str, str, str]]:
         """).fetchall()
     }
 
-    chapter_rows = conn.execute("""
+    chapter_sql = """
         SELECT
             c.path,
             c.chapter_num,
@@ -512,7 +524,12 @@ def _scan_settings_naming_issues() -> list[tuple[str, str, str]]:
         LEFT JOIN volumes v ON v.id = c.volume_id
         WHERE c.path IS NOT NULL
           AND COALESCE(s.exclude_from_fix, 0) = 0
-    """).fetchall()
+    """
+    chapter_params: list[str] = []
+    if series_scope:
+        chapter_sql += "\n          AND s.path = ?"
+        chapter_params.append(series_scope)
+    chapter_rows = conn.execute(chapter_sql, chapter_params).fetchall()
 
     for row in chapter_rows:
         old_path = os.path.join(MANGA_ROOT, row["path"])
@@ -543,7 +560,7 @@ def _scan_settings_naming_issues() -> list[tuple[str, str, str]]:
         if target != old_path and not os.path.exists(target):
             findings.append((old_path, "settings_chapter_naming", new_name))
 
-    volume_rows = conn.execute("""
+    volume_sql = """
         SELECT
             v.id,
             v.path,
@@ -555,7 +572,12 @@ def _scan_settings_naming_issues() -> list[tuple[str, str, str]]:
         JOIN series s ON s.id = v.series_id
         WHERE v.path IS NOT NULL
           AND COALESCE(s.exclude_from_fix, 0) = 0
-    """).fetchall()
+    """
+    volume_params: list[str] = []
+    if series_scope:
+        volume_sql += "\n          AND s.path = ?"
+        volume_params.append(series_scope)
+    volume_rows = conn.execute(volume_sql, volume_params).fetchall()
 
     for row in volume_rows:
         old_path = os.path.join(MANGA_ROOT, row["path"])
@@ -697,7 +719,16 @@ def _human_size(size: int | None) -> str:
 
 def get_all_series() -> list[dict]:
     conn = _get_conn()
-    return _db.get_all_series(conn)
+    rows = _db.get_all_series(conn)
+    roots = _root_folders()
+    if not roots:
+        return rows
+    out: list[dict] = []
+    for row in rows:
+        p = (row.get("path") or "").replace("\\", "/").strip()
+        if any(p == rf or p.startswith(rf + "/") for rf in roots):
+            out.append(row)
+    return out
 
 
 def get_subdirs() -> list[str]:
@@ -807,6 +838,14 @@ async def _fetch_groups(manga_id: str, language: str) -> dict:
 
 def _no_rf() -> bool:
     return not _root_folders()
+
+
+def _require_root_folders() -> None:
+    if _no_rf():
+        raise HTTPException(
+            400,
+            "Configure at least one root folder in Settings before running this action.",
+        )
 
 
 class DeleteSeriesFilesBody(BaseModel):
@@ -1051,8 +1090,7 @@ async def series_details_page(request: Request, path: str):
 
 @app.get("/sync", response_class=HTMLResponse)
 async def sync_page(request: Request):
-    return templates.TemplateResponse(request=request, name="sync.html",
-        context={"active": "sync", "no_root_folders": _no_rf()})
+    return RedirectResponse("/jobs", status_code=307)
 
 
 @app.get("/jobs", response_class=HTMLResponse)
@@ -1388,6 +1426,7 @@ async def add_series(
     exclude_from_fix: str = Form("false"),
     merge_volumes_override: str = Form(""),
 ):
+    _require_root_folders()
     parts      = [p for p in [subfolder.strip("/"), title] if p]
     series_dir = os.path.join(MANGA_ROOT, *parts)
     os.makedirs(series_dir, exist_ok=True)
@@ -1471,6 +1510,7 @@ async def series_cover(path: str):
 
 @app.delete("/api/series/{path:path}", response_class=HTMLResponse)
 async def delete_series(path: str):
+    _require_root_folders()
     conn = _get_conn()
     if not _db.get_series_by_path(conn, path):
         raise HTTPException(404, "Series not found")
@@ -1587,6 +1627,7 @@ async def update_series(
     merge_volumes_override: str = Form(""),
     mark_sync_configured: str = Form(""),
 ):
+    _require_root_folders()
     # path here is the URL route parameter (old path)
     old_dir    = os.path.join(MANGA_ROOT, path)
     parts      = [p for p in [subfolder.strip("/"), title] if p]
@@ -1633,6 +1674,7 @@ async def update_series(
 
 @app.post("/api/jobs/sync-all")
 async def enqueue_sync_all():
+    _require_root_folders()
     conn = _get_conn()
     active = _db.get_active_jobs(conn, queue_key=JOB_QUEUE_KEY)
     for j in active:
@@ -1647,8 +1689,26 @@ async def enqueue_sync_all():
     return JSONResponse({"ok": True, "job": _serialize_job(_db.get_job(conn, job_id)), "deduped": False})
 
 
+@app.post("/api/jobs/reconcile-disk")
+async def enqueue_reconcile_disk():
+    _require_root_folders()
+    conn = _get_conn()
+    active = _db.get_active_jobs(conn, queue_key=JOB_QUEUE_KEY)
+    for j in active:
+        if j.get("job_type") == JOB_TYPE_RECONCILE_DISK:
+            return JSONResponse({"ok": True, "job": _serialize_job(j), "deduped": True})
+    job_id = _db.enqueue_job(
+        conn,
+        job_type=JOB_TYPE_RECONCILE_DISK,
+        queue_key=JOB_QUEUE_KEY,
+        payload={"reason": "manual"},
+    )
+    return JSONResponse({"ok": True, "job": _serialize_job(_db.get_job(conn, job_id)), "deduped": False})
+
+
 @app.post("/api/jobs/sync-series/{path:path}")
 async def enqueue_sync_series(path: str):
+    _require_root_folders()
     conn = _get_conn()
     row = _db.get_series_by_path(conn, path)
     if not row:
@@ -1669,6 +1729,7 @@ async def enqueue_sync_series(path: str):
 
 @app.post("/api/jobs/regenerate-comicinfo/{path:path}")
 async def enqueue_regenerate_comicinfo(path: str):
+    _require_root_folders()
     conn = _get_conn()
     row = _db.get_series_by_path(conn, path)
     if not row:
@@ -1753,6 +1814,7 @@ async def stream_job(job_id: int, from_seq: int = 0):
 
     async def generate():
         nonlocal from_seq
+        last_status_sent = None
         while True:
             lines = _db.get_job_logs_since(conn, job_id, from_seq=from_seq, limit=200)
             for ln in lines:
@@ -1769,14 +1831,17 @@ async def stream_job(job_id: int, from_seq: int = 0):
                 payload = {"type": "status", "status": "missing"}
                 yield f"data: {json.dumps(payload, ensure_ascii=False)}\n\n"
                 break
-            if job["status"] in JOB_STATUS_TERMINAL:
+            cur_status = job.get("status")
+            if cur_status != last_status_sent:
                 payload = {
                     "type": "status",
-                    "status": job["status"],
+                    "status": cur_status,
                     "exit_code": job.get("exit_code"),
                     "error_summary": job.get("error_summary"),
                 }
                 yield f"data: {json.dumps(payload, ensure_ascii=False)}\n\n"
+                last_status_sent = cur_status
+            if job["status"] in JOB_STATUS_TERMINAL:
                 break
             await asyncio.sleep(0.4)
 
@@ -1855,6 +1920,7 @@ async def series_sync_stream(path: str):
 
 @app.post("/api/series/{path:path}/covers")
 async def series_covers(path: str):
+    _require_root_folders()
     conn = _get_conn()
     row  = _db.get_series_by_path(conn, path)
     if not row:
@@ -1880,6 +1946,7 @@ async def series_covers(path: str):
 
 @app.post("/api/series/{path:path}/comicinfo-regenerate")
 async def series_regenerate_comicinfo(path: str):
+    _require_root_folders()
     conn = _get_conn()
     if not _db.get_series_by_path(conn, path):
         raise HTTPException(404, "Series not found")
@@ -1908,6 +1975,7 @@ async def series_regenerate_comicinfo(path: str):
 
 @app.get("/api/series/{path:path}/comicinfo-regenerate/stream")
 async def series_regenerate_comicinfo_stream(path: str):
+    _require_root_folders()
     conn = _get_conn()
     if not _db.get_series_by_path(conn, path):
         raise HTTPException(404, "Series not found")
@@ -1949,6 +2017,7 @@ async def series_regenerate_comicinfo_stream(path: str):
 
 @app.post("/api/series/{path:path}/compact-volumes")
 async def series_compact_volumes(path: str):
+    _require_root_folders()
     conn = _get_conn()
     if not _db.get_series_by_path(conn, path):
         raise HTTPException(404, "Series not found")
@@ -1984,6 +2053,7 @@ async def series_reset_source_metadata(path: str):
     English archives). Catalog rows that have no file are left intact, so
     sync can still discover and download missing chapters afterwards.
     """
+    _require_root_folders()
     conn = _get_conn()
     row = _db.get_series_by_path(conn, path)
     if not row:
@@ -1995,6 +2065,7 @@ async def series_reset_source_metadata(path: str):
 @app.post("/api/series/{path:path}/delete-files")
 async def series_delete_files(path: str, body: DeleteSeriesFilesBody):
     """Delete chapter/volume archive files on disk for this series; DB is reconciled via scan."""
+    _require_root_folders()
     conn = _get_conn()
     row = _db.get_series_by_path(conn, path)
     if not row:
@@ -2130,6 +2201,7 @@ async def get_chapter_comicinfo(path: str, chapter_id: int):
 
 @app.put("/api/comicinfo/series/{path:path}/chapters/{chapter_id}")
 async def update_chapter_comicinfo(path: str, chapter_id: int, body: ComicInfoUpdateBody):
+    _require_root_folders()
     conn = _get_conn()
     row = _db.get_series_by_path(conn, path)
     if not row:
@@ -2197,6 +2269,7 @@ async def get_volume_comicinfo(path: str, volume_id: int):
 
 @app.put("/api/comicinfo/series/{path:path}/volumes/{volume_id}")
 async def update_volume_comicinfo(path: str, volume_id: int, body: ComicInfoUpdateBody):
+    _require_root_folders()
     conn = _get_conn()
     row = _db.get_series_by_path(conn, path)
     if not row:
@@ -2237,6 +2310,7 @@ async def apply_fix(
     new_name:   str = Form(...),
     issue_name: str = Form(...),
 ):
+    _require_root_folders()
     log_path = os.path.join(MANGA_ROOT, _fix.LOG_FILENAME)
     log_data = _fix.load_log(log_path)
     try:
@@ -2249,6 +2323,7 @@ async def apply_fix(
 
 @app.post("/api/fix/series-skip", response_class=HTMLResponse)
 async def skip_series_from_fix(series_path: str = Form(...)):
+    _require_root_folders()
     conn = _get_conn()
     row = _db.get_series_by_path(conn, series_path)
     if not row:
@@ -2274,6 +2349,59 @@ async def skip_series_from_fix(series_path: str = Form(...)):
     return HTMLResponse("")
 
 
+@app.post("/api/fix/series-apply-all")
+async def apply_all_series_fixes(series_path: str = Form(...)):
+    _require_root_folders()
+    conn = _get_conn()
+    row = _db.get_series_by_path(conn, series_path)
+    if not row:
+        raise HTTPException(404, "Series not found")
+    series_dir = os.path.join(MANGA_ROOT, series_path)
+    if not os.path.isdir(series_dir):
+        raise HTTPException(404, "Series folder not found on disk")
+
+    log_path = os.path.join(MANGA_ROOT, _fix.LOG_FILENAME)
+    log_data = _fix.load_log(log_path)
+    renamed = 0
+    skipped_missing = 0
+    seen_paths: set[str] = set()
+
+    findings = list(_fix.scan(series_dir))
+    findings.extend(_scan_settings_naming_issues(series_path=series_path))
+    findings.sort(key=lambda x: x[0].lower())
+    for old_path, issue_name, new_name in findings:
+        if old_path in seen_paths:
+            continue
+        seen_paths.add(old_path)
+        if not os.path.exists(old_path):
+            skipped_missing += 1
+            continue
+        try:
+            _fix.do_rename(old_path, new_name, issue_name, log_data, log_path)
+            renamed += 1
+        except Exception:
+            continue
+
+    dup_groups = _fix.scan_duplicates(series_dir)
+    dedup_applied = 0
+    for group in dup_groups:
+        try:
+            _fix.apply_dup_group(group, log_data, log_path)
+            dedup_applied += 1
+        except Exception:
+            continue
+
+    _db.scan_disk_files(series_dir, row["id"], conn)
+    return JSONResponse({
+        "ok": True,
+        "series_path": series_path,
+        "renamed": renamed,
+        "dedup_groups": dedup_applied,
+        "resolved": renamed + dedup_applied,
+        "skipped_missing": skipped_missing,
+    })
+
+
 @app.post("/api/fix/apply-dup", response_class=HTMLResponse)
 async def apply_dup(
     keep_path:    str = Form(...),
@@ -2281,6 +2409,7 @@ async def apply_dup(
     needs_rename: str = Form(""),
     keep_name:    str = Form(...),
 ):
+    _require_root_folders()
     log_path = os.path.join(MANGA_ROOT, _fix.LOG_FILENAME)
     log_data = _fix.load_log(log_path)
     all_paths = [keep_path] + [x for x in delete_paths.split("|") if x]

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -345,8 +345,6 @@
          '<svg viewBox="0 0 14 14" fill="currentColor" width="14" height="14" aria-hidden="true" style="flex-shrink:0"><rect x="0" y="0" width="6" height="6" rx="1.2"/><rect x="8" y="0" width="6" height="6" rx="1.2"/><rect x="0" y="8" width="6" height="6" rx="1.2"/><rect x="8" y="8" width="6" height="6" rx="1.2"/></svg>'),
         ("series",   "/series",    "Add Series",
          '<svg viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" width="14" height="14" aria-hidden="true" style="flex-shrink:0"><circle cx="7" cy="7" r="5.5"/><line x1="7" y1="4.5" x2="7" y2="9.5"/><line x1="4.5" y1="7" x2="9.5" y2="7"/></svg>'),
-        ("sync",     "/sync",      "Sync",
-         '<svg viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" width="14" height="14" aria-hidden="true" style="flex-shrink:0"><path d="M1 4.5C1.8 2.5 3.8 1 6 1c2.5 0 4.5 1.5 5 3.5"/><polyline points="9.5,1 11,4.5 7.5,5.5"/><path d="M13 9.5C12.2 11.5 10.2 13 8 13c-2.5 0-4.5-1.5-5-3.5"/><polyline points="4.5,13 3,9.5 6.5,8.5"/></svg>'),
         ("jobs",     "/jobs",      "Jobs",
          '<svg viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" width="14" height="14" aria-hidden="true" style="flex-shrink:0"><rect x="1.5" y="1.5" width="11" height="11" rx="2"/><path d="M4 4.5h6M4 7h6M4 9.5h4"/></svg>'),
         ("fix",      "/fix",       "Fix Files",

--- a/web/templates/fix.html
+++ b/web/templates/fix.html
@@ -1,5 +1,26 @@
 {% extends "base.html" %}
 {% block content %}
+{% if no_root_folders %}
+<div class="mb-8">
+  <h1 class="text-2xl font-bold" style="font-family:'Syne',sans-serif">Fix Files</h1>
+  <p class="text-sm mt-1" style="color:var(--text-muted)">Filename cleanup runs only after you configure library roots.</p>
+</div>
+<div class="max-w-lg">
+  <div class="rounded-xl border p-10 text-center"
+       style="background:var(--surface);border-color:rgba(251,191,36,.3)">
+    <div class="mb-4 text-4xl opacity-30">📁</div>
+    <p class="font-semibold text-sm" style="color:#fbbf24;font-family:'Syne',sans-serif">Root folder required</p>
+    <p class="text-xs mt-2 mb-6" style="color:var(--text-muted)">
+      Add at least one root folder in Settings, then return here to fix names.
+    </p>
+    <a href="/settings"
+       class="inline-block text-xs font-semibold px-5 py-2.5 rounded-lg bg-violet-600 hover:bg-violet-700 text-white transition-colors"
+       style="font-family:'Syne',sans-serif">
+      Open Settings →
+    </a>
+  </div>
+</div>
+{% else %}
 <div class="mb-8 flex items-center justify-between">
   <div>
     <h1 class="text-2xl font-bold" style="font-family:'Syne',sans-serif">Fix Files</h1>
@@ -36,15 +57,22 @@
         </p>
       </div>
       {% if sg.series_path %}
-      <form hx-post="/api/fix/series-skip" hx-target="closest .series-fix-card" hx-swap="outerHTML"
-            hx-confirm="Ignore '{{ sg.series_title }}' in Fix Files from now on?"
-            onclick="event.stopPropagation()">
-        <input type="hidden" name="series_path" value="{{ sg.series_path }}">
-        <button class="text-xs px-3 py-1.5 rounded-lg border transition-colors"
-                style="border-color:rgba(251,191,36,.45);color:#fbbf24">
-          Ignore This Series
+      <div class="flex gap-2" onclick="event.stopPropagation()">
+        <button type="button"
+                onclick="fixAllInSeries(this, {{ sg.series_path|tojson }}, {{ sg.series_title|tojson }})"
+                class="text-xs px-3 py-1.5 rounded-lg border transition-colors"
+                style="border-color:rgba(139,92,246,.45);color:var(--accent-light)">
+          Fix All In This Series
         </button>
-      </form>
+        <form hx-post="/api/fix/series-skip" hx-target="closest .series-fix-card" hx-swap="outerHTML"
+              hx-confirm="Ignore '{{ sg.series_title }}' in Fix Files from now on?">
+          <input type="hidden" name="series_path" value="{{ sg.series_path }}">
+          <button class="text-xs px-3 py-1.5 rounded-lg border transition-colors"
+                  style="border-color:rgba(251,191,36,.45);color:#fbbf24">
+            Ignore This Series
+          </button>
+        </form>
+      </div>
       {% endif %}
     </summary>
 
@@ -114,10 +142,36 @@
   <p class="text-base" style="color:var(--text-muted)">Library looks clean!</p>
 </div>
 {% endif %}
+{% endif %}
 
 <script>
 function fixAll() {
   document.querySelectorAll('.issue-card form button, .dup-card form button').forEach(btn => btn.click());
+}
+
+async function fixAllInSeries(btn, seriesPath, seriesTitle) {
+  if (!seriesPath) return;
+  const ok = await window.appConfirm("Apply all fixes in '" + seriesTitle + "'?");
+  if (!ok) return;
+  const original = btn.textContent;
+  btn.disabled = true;
+  btn.textContent = 'Fixing...';
+  try {
+    const body = new URLSearchParams();
+    body.set('series_path', seriesPath);
+    const resp = await fetch('/api/fix/series-apply-all', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    });
+    const data = await resp.json();
+    if (!resp.ok || !data.ok) throw new Error(data.error || 'Failed to apply fixes');
+    window.location.reload();
+  } catch (err) {
+    btn.disabled = false;
+    btn.textContent = original;
+    alert(String(err));
+  }
 }
 </script>
 {% endblock %}

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -243,6 +243,27 @@
   }
 </style>
 
+{% if no_root_folders %}
+<div class="mb-6">
+  <h1 class="text-2xl font-bold" style="font-family:'Syne',sans-serif">Dashboard</h1>
+  <p class="text-sm mt-1" style="color:var(--text-muted)">Set up library root folder(s) before tracking series or running sync.</p>
+</div>
+<div class="max-w-lg">
+  <div class="rounded-xl border p-10 text-center"
+       style="background:var(--surface);border-color:rgba(251,191,36,.3)">
+    <div class="mb-4 text-4xl opacity-30">📁</div>
+    <p class="font-semibold text-sm" style="color:#fbbf24;font-family:'Syne',sans-serif">Root folder required</p>
+    <p class="text-xs mt-2 mb-6" style="color:var(--text-muted)">
+      Add at least one folder under your manga mount (for example <span class="font-mono">en</span> or <span class="font-mono">jp</span>). Nothing is scanned or synced until then.
+    </p>
+    <a href="/settings"
+       class="inline-block text-xs font-semibold px-5 py-2.5 rounded-lg bg-violet-600 hover:bg-violet-700 text-white transition-colors"
+       style="font-family:'Syne',sans-serif">
+      Open Settings →
+    </a>
+  </div>
+</div>
+{% else %}
 <div class="mb-6 flex items-center justify-between gap-3">
   <div>
     <h1 class="text-2xl font-bold" style="font-family:'Syne',sans-serif">Dashboard</h1>
@@ -268,7 +289,7 @@
         </svg>
       </button>
     </div>
-    <a href="/sync"
+    <a href="/jobs"
        class="bg-violet-600 hover:bg-violet-700 text-white text-xs font-semibold px-4 py-2 rounded-lg transition-colors"
        style="font-family:'Syne',sans-serif;letter-spacing:.02em">
       Sync All
@@ -390,18 +411,23 @@
 </div>
 
 {% endif %}
+{% endif %}
 
 <script>
 /* ── View toggle ─────────────────────────────────────── */
 function setView(v) {
+  const grid = document.getElementById('series-grid');
+  const list = document.getElementById('series-list');
+  if (!grid || !list) return;
   const isGrid = v === 'grid';
-  document.getElementById('series-grid').style.display = isGrid ? '' : 'none';
-  document.getElementById('series-list').style.display = isGrid ? 'none' : '';
+  grid.style.display = isGrid ? '' : 'none';
+  list.style.display = isGrid ? 'none' : '';
   document.getElementById('btn-grid').classList.toggle('active', isGrid);
   document.getElementById('btn-list').classList.toggle('active', !isGrid);
   localStorage.setItem('dash-view', v);
 }
 (function() {
+  if (!document.getElementById('series-grid')) return;
   const saved = localStorage.getItem('dash-view') || 'grid';
   setView(saved);
 })();

--- a/web/templates/jobs.html
+++ b/web/templates/jobs.html
@@ -2,8 +2,50 @@
 {% block content %}
 <div class="mb-8">
   <h1 class="text-2xl font-bold" style="font-family:'Syne',sans-serif">Jobs</h1>
-  <p class="text-sm mt-1" style="color:var(--text-muted)">Running, queued, and recent sync jobs</p>
+  <p class="text-sm mt-1" style="color:var(--text-muted)">Launch maintenance jobs and watch running, queued, and recent activity</p>
 </div>
+
+{% if no_root_folders %}
+<div class="rounded-xl border p-4 mb-4" style="background:var(--surface);border-color:rgba(251,191,36,.3)">
+  <p class="text-sm font-semibold" style="color:#fbbf24;font-family:'Syne',sans-serif">Launchboard disabled</p>
+  <p class="text-xs mt-1" style="color:var(--text-muted)">Configure at least one root folder in Settings to run sync or disk reconcile. You can still browse the job queue and logs below.</p>
+  <a href="/settings" class="inline-block text-xs font-semibold mt-3 px-4 py-2 rounded-lg bg-violet-600 hover:bg-violet-700 text-white transition-colors" style="font-family:'Syne',sans-serif">Settings →</a>
+</div>
+{% else %}
+<div class="rounded-xl border p-4 mb-4" style="background:var(--surface);border-color:var(--border)">
+  <div class="flex items-center justify-between gap-2 mb-3">
+    <h2 class="text-sm font-semibold" style="font-family:'Syne',sans-serif;color:var(--text)">Launchboard</h2>
+    <span class="text-xs" style="color:var(--text-dim)">Quick actions enqueue jobs in the shared queue.</span>
+  </div>
+  <div class="grid gap-3 md:grid-cols-2">
+    <div class="rounded-lg border p-3" style="background:var(--surface-alt);border-color:var(--border-mid)">
+      <div class="flex items-start justify-between gap-3">
+        <div>
+          <div class="text-sm font-semibold" style="font-family:'Syne',sans-serif;color:var(--text)">Sync All Series</div>
+          <p class="text-xs mt-1" style="color:var(--text-dim)">Runs MangaDex sync across all linked series and applies post-sync routines.</p>
+        </div>
+        <button type="button" data-launch-kind="sync-all" onclick="launchJob(this, '/api/jobs/sync-all')"
+                class="bg-violet-600 hover:bg-violet-700 text-white text-xs font-semibold px-3 py-2 rounded-lg transition-colors">
+          Launch
+        </button>
+      </div>
+    </div>
+    <div class="rounded-lg border p-3" style="background:var(--surface-alt);border-color:var(--border-mid)">
+      <div class="flex items-start justify-between gap-3">
+        <div>
+          <div class="text-sm font-semibold" style="font-family:'Syne',sans-serif;color:var(--text)">Disk Reconcile</div>
+          <p class="text-xs mt-1" style="color:var(--text-dim)">Rescans root folders, discovers local series, and refreshes tracked files in the DB.</p>
+        </div>
+        <button type="button" data-launch-kind="reconcile-disk" onclick="launchJob(this, '/api/jobs/reconcile-disk')"
+                class="text-xs font-semibold px-3 py-2 rounded-lg border transition-colors"
+                style="border-color:var(--border-hi);color:var(--text-muted)">
+          Launch
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+{% endif %}
 
 <div class="rounded-xl border p-3 mb-4 flex flex-wrap items-center gap-2.5"
      style="background:var(--surface);border-color:var(--border)">
@@ -35,6 +77,25 @@ let jobStream = null;
 let latestSeq = 0;
 let jobsAutoScroll = true;
 let jobsFilter = '';
+let statusHintShownForJob = {};
+
+async function launchJob(btn, endpoint) {
+  const original = btn.textContent;
+  btn.disabled = true;
+  btn.textContent = 'Launching...';
+  try {
+    const resp = await fetch(endpoint, { method: 'POST' });
+    const data = await resp.json();
+    if (!resp.ok || !data.ok || !data.job) throw new Error(data.error || 'Could not enqueue job');
+    await refreshJobsList();
+    selectJob(data.job.id);
+  } catch (e) {
+    appendConsoleLine('[ui] launch error: ' + String(e));
+  } finally {
+    btn.disabled = false;
+    btn.textContent = original;
+  }
+}
 
 function statusBadge(status) {
   if (status === 'running') return '<span class="text-[11px] px-1.5 py-0.5 rounded" style="background:rgba(52,211,153,.14);color:#34d399">running</span>';
@@ -129,6 +190,7 @@ function appendConsoleLine(text) {
 function selectJob(jobId) {
   selectedJobId = jobId;
   latestSeq = 0;
+  statusHintShownForJob[jobId] = false;
   if (jobStream) {
     jobStream.close();
     jobStream = null;
@@ -147,6 +209,10 @@ function selectJob(jobId) {
         document.getElementById('job-console-status').textContent = 'Live';
       } else if (payload.type === 'status') {
         document.getElementById('job-console-status').textContent = payload.status || 'done';
+        if ((payload.status === 'queued' || payload.status === 'running') && !statusHintShownForJob[jobId]) {
+          appendConsoleLine('[job] status: ' + payload.status + ' (waiting for output)');
+          statusHintShownForJob[jobId] = true;
+        }
         if (payload.status === 'completed' || payload.status === 'failed' || payload.status === 'cancelled' || payload.status === 'missing') {
           jobStream.close();
           jobStream = null;

--- a/web/templates/series_detail.html
+++ b/web/templates/series_detail.html
@@ -361,12 +361,24 @@ function seriesDetailApiUrl(path, suffix) {
   return '/api/series/' + path.split('/').map(encodeURIComponent).join('/') + suffix;
 }
 
+function appendDetailJobStatusHint(logEl, status) {
+  if (!logEl) return;
+  if (status !== 'queued' && status !== 'running') return;
+  if ((logEl.dataset.statusHintShown || '') === status) return;
+  var line = document.createElement('div');
+  line.textContent = '[job] status: ' + status + ' (waiting for output)';
+  logEl.appendChild(line);
+  logEl.scrollTop = logEl.scrollHeight;
+  logEl.dataset.statusHintShown = status;
+}
+
 function detailSeriesSync(btn) {
   var path = btn.dataset.path;
   var log = document.getElementById('detail-action-log');
   btn.disabled = true;
   btn.textContent = '…';
   log.innerHTML = '';
+  log.dataset.statusHintShown = '';
   log.classList.remove('hidden');
   fetch('/api/jobs/sync-series/' + path.split('/').map(encodeURIComponent).join('/'), { method: 'POST' })
     .then(function(r) { return r.json(); })
@@ -403,6 +415,7 @@ function bindSeriesJobStream(jobId, path, btn) {
     if (payload.type === 'status') {
       if (payload.status === 'queued' && btn) btn.textContent = 'Queued';
       if (payload.status === 'running' && btn) btn.textContent = 'Running';
+      appendDetailJobStatusHint(log, payload.status);
       if (payload.status === 'completed' || payload.status === 'failed' || payload.status === 'cancelled' || payload.status === 'missing') {
         es.close();
         if (btn) {
@@ -453,6 +466,7 @@ async function detailSeriesResetSourceMetadata(btn) {
   btn.disabled = true;
   btn.textContent = '…';
   log.textContent = '';
+  log.dataset.statusHintShown = '';
   log.classList.remove('hidden');
   try {
     var resp = await fetch(seriesDetailApiUrl(path, '/reset-source-metadata'), { method: 'POST' });
@@ -482,6 +496,7 @@ async function detailSeriesResetSourceMetadata(btn) {
       if (payload.type === 'status') {
         if (payload.status === 'queued') btn.textContent = 'Queued';
         if (payload.status === 'running') btn.textContent = 'Running';
+        appendDetailJobStatusHint(log, payload.status);
         if (payload.status === 'completed' || payload.status === 'failed' || payload.status === 'cancelled' || payload.status === 'missing') {
           es.close();
           btn.textContent = payload.status === 'completed' ? '✓' : '✗';
@@ -509,6 +524,7 @@ async function detailSeriesRegenerateComicInfo(btn) {
   btn.disabled = true;
   btn.textContent = '…';
   log.textContent = '';
+  log.dataset.statusHintShown = '';
   log.classList.remove('hidden');
   try {
     var resp = await fetch('/api/jobs/regenerate-comicinfo/' + path.split('/').map(encodeURIComponent).join('/'), { method: 'POST' });
@@ -529,6 +545,7 @@ async function detailSeriesRegenerateComicInfo(btn) {
       if (payload.type === 'status') {
         if (payload.status === 'queued') btn.textContent = 'Queued';
         if (payload.status === 'running') btn.textContent = 'Running';
+        appendDetailJobStatusHint(log, payload.status);
         if (payload.status === 'completed' || payload.status === 'failed' || payload.status === 'cancelled' || payload.status === 'missing') {
           es.close();
           btn.textContent = payload.status === 'completed' ? '✓' : '✗';


### PR DESCRIPTION
- Gate dashboard, fix page, jobs launchboard until root folders configured
- Require roots for mutating APIs; skip reconcile/sync cron without roots
- scan_disk_series: empty allowed_roots discovers nothing; reconcile respects roots
- Kavita client: browser-like User-Agent for Cloudflare
- Jobs/series detail: queued/running status hints in consoles
- Fix Files: series bulk fix; /sync redirects to /jobs; nav cleanup
- Force merge_volumes off in normal sync path; default merge_volumes false