### PR TITLE
refactor: extract shared naming module, fix hardcoded paths and depre…

### DIFF
--- a/manga-sync.py
+++ b/manga-sync.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 """manga-sync — download new chapters, merge volumes, inject ComicInfo.xml."""
 
+import contextlib
 import importlib.util
+import json
 import math
 import os
 import re
@@ -52,6 +54,7 @@ from comicinfo import (                                 # noqa: E402
 from sync_config import load_settings, sanitize_volume_naming  # noqa: E402
 from kavita import KavitaClient                        # noqa: E402
 from file_permissions import apply_file_permission_mask # noqa: E402
+from naming import apply_naming_template, floor_int_str # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -87,7 +90,7 @@ def _api_get(path: str, params: dict) -> dict:
     url = f"{MDEX_BASE}{path}?" + parse.urlencode(params, doseq=True)
     try:
         with request.urlopen(url, timeout=30) as resp:
-            return __import__("json").loads(resp.read())
+            return json.loads(resp.read())
     except urlerror.HTTPError as e:
         raise RuntimeError(f"HTTP {e.code} for {url}") from e
 
@@ -395,66 +398,6 @@ def _mdx_download(
 # Volume merging
 # ---------------------------------------------------------------------------
 
-def _apply_template(template: str, lang: str, group: str, title: str, vol_num,
-                    ch_range: str = "") -> str:
-    def _safe(s):
-        return re.sub(r'[<>:"/\\|?*]', "_", str(s or ""))
-
-    result = template
-    result = result.replace("%1", _safe(lang))
-    result = result.replace("%2", _safe(group))
-    result = result.replace("%3", _safe(title))
-    result = result.replace("%4", str(int(vol_num)) if vol_num is not None else "")
-    result = result.replace("%5", ch_range).replace("%6", "")
-    # Drop empty grouping wrappers left by missing placeholders like %2.
-    result = re.sub(r"\(\s*\)", "", result)
-    result = re.sub(r"\[\s*\]", "", result)
-    result = re.sub(r"\{\s*\}", "", result)
-    result = re.sub(r"\s+([)\]}])", r"\1", result)
-    result = re.sub(r"([(\[{])\s+", r"\1", result)
-    result = re.sub(r"\s{2,}", " ", result).strip()
-    return result
-
-
-def _apply_chapter_template(
-    template: str,
-    *,
-    lang: str,
-    group: str,
-    title: str,
-    vol_num,
-    chapter_num,
-    chapter_title: str | None,
-) -> str:
-    def _safe(s):
-        return re.sub(r'[<>:"/\\|?*]', "_", str(s or ""))
-
-    result = template or ""
-    result = result.replace("%1", _safe(lang))
-    result = result.replace("%2", _safe(group))
-    result = result.replace("%3", _safe(title))
-    result = result.replace("%4", str(int(vol_num)) if vol_num is not None else "")
-    result = result.replace("%5", _fmt_chapter_token(chapter_num) if chapter_num is not None else "")
-    result = result.replace("%6", _safe(chapter_title or ""))
-    # Drop empty grouping wrappers left by missing placeholders like %2 or %6.
-    result = re.sub(r"\(\s*\)", "", result)
-    result = re.sub(r"\[\s*\]", "", result)
-    result = re.sub(r"\{\s*\}", "", result)
-    result = re.sub(r"\s+([)\]}])", r"\1", result)
-    result = re.sub(r"([(\[{])\s+", r"\1", result)
-    result = re.sub(r"\s{2,}", " ", result).strip()
-    return result
-
-
-def _fmt_chapter_for_range(n) -> str:
-    return str(math.floor(float(n)))
-
-
-def _fmt_chapter_token(n) -> str:
-    num = float(n)
-    return str(int(num)) if num.is_integer() else str(num)
-
-
 def _volume_cbz_comicinfo_xml(
     *,
     series_title: str,
@@ -478,9 +421,9 @@ def _volume_cbz_comicinfo_xml(
     desc = (meta or {}).get("description")
     if chapter_lo is not None and chapter_hi is not None:
         ch_range = (
-            _fmt_chapter_for_range(chapter_lo)
+            floor_int_str(chapter_lo)
             if chapter_lo == chapter_hi
-            else f"{_fmt_chapter_for_range(chapter_lo)}-{_fmt_chapter_for_range(chapter_hi)}"
+            else f"{floor_int_str(chapter_lo)}-{floor_int_str(chapter_hi)}"
         )
         prefix = f"This volume contains chapters {ch_range}."
         desc = f"{prefix}\n\n{desc}" if desc else prefix
@@ -669,8 +612,9 @@ def _merge_volume_batch(
         group_name = ch_rows[0].get("group_name") or preferred_group or ""
         # Never pass chapter span into the filename template (Kavita); span is
         # only in ComicInfo summary.
-        base_name  = _apply_template(volume_naming, language or "en",
-                                     group_name, series_title, vol_num, "")
+        base_name  = apply_naming_template(volume_naming, language=language or "en",
+                                          group=group_name, title=series_title,
+                                          volume_num=vol_num)
         out_name   = base_name if base_name.endswith(f".{file_format}") \
                      else f"{base_name}.{file_format}"
         out_path   = os.path.join(series_dir, out_name)
@@ -932,10 +876,6 @@ def _run_fix_pass(series_dir: str):
 def _kavita_set_covers(client: KavitaClient, series_dir: str, manga_id: str):
     series_name = os.path.basename(series_dir)
     try:
-        from manga_sync_helpers import fetch_volume_covers  # type: ignore
-    except ImportError:
-        pass
-    try:
         data = _api_get("/cover", {
             "manga[]": manga_id, "limit": 100, "order[volume]": "asc",
         })
@@ -1056,14 +996,14 @@ def _sync_one_series(
                     ).fetchone()
                     if vr:
                         vol_num = vr["volume_num"]
-                desired_stem = _apply_chapter_template(
+                desired_stem = apply_naming_template(
                     ch_naming,
-                    lang=language,
+                    language=language,
                     group=ch_row.get("group_name") or "",
                     title=name,
-                    vol_num=vol_num,
+                    volume_num=vol_num,
                     chapter_num=ch_row["chapter_num"],
-                    chapter_title=ch_row.get("title"),
+                    chapter_title=ch_row.get("title") or "",
                 )
                 if desired_stem:
                     ext = os.path.splitext(fpath)[1]

--- a/naming.py
+++ b/naming.py
@@ -1,0 +1,65 @@
+"""Shared filename template logic used by both manga-sync and the web app."""
+import math
+import re
+
+
+def safe_filename_token(value) -> str:
+    return re.sub(r'[<>:"/\\|?*]', "_", str(value or ""))
+
+
+def format_num(value) -> str:
+    if value is None:
+        return ""
+    try:
+        num = float(value)
+    except (TypeError, ValueError):
+        return str(value)
+    return str(int(num)) if num.is_integer() else str(num)
+
+
+def floor_int_str(value) -> str:
+    """Floor a numeric value and return it as a string (e.g. 3.5 → '3'). Falls back to format_num."""
+    try:
+        return str(math.floor(float(value)))
+    except (TypeError, ValueError):
+        return format_num(value)
+
+
+def apply_naming_template(
+    template: str,
+    *,
+    language: str = "",
+    group: str = "",
+    title: str = "",
+    volume_num=None,
+    chapter_num=None,
+    chapter_title: str = "",
+    chapter_range: str = "",
+) -> str:
+    """Apply %%1-%%6 filename template substitutions.
+
+    %%1=language, %%2=group, %%3=series title, %%4=volume, %%5=chapter or range,
+    %%6=chapter title.
+    """
+    result = template or ""
+    if volume_num is None:
+        result = re.sub(r"\bvol(?:ume)?\.?\s*%4\b", "", result, flags=re.IGNORECASE)
+        result = re.sub(r"\bvol(?:ume)?\.?\s*$", "", result, flags=re.IGNORECASE)
+    if chapter_num is None and not chapter_range:
+        result = re.sub(r"\bch\.?\s*%5\b", "", result, flags=re.IGNORECASE)
+    result = result.replace("%1", safe_filename_token(language))
+    result = result.replace("%2", safe_filename_token(group))
+    result = result.replace("%3", safe_filename_token(title))
+    result = result.replace("%4", format_num(volume_num))
+    result = result.replace("%5", chapter_range or format_num(chapter_num))
+    result = result.replace("%6", safe_filename_token(chapter_title))
+    result = re.sub(r"\(\s*\)", "", result)
+    result = re.sub(r"\[\s*\]", "", result)
+    result = re.sub(r"\{\s*\}", "", result)
+    result = re.sub(r"\bch\.?\s*$", "", result, flags=re.IGNORECASE)
+    result = re.sub(r"\bvol(?:ume)?\.?\s*$", "", result, flags=re.IGNORECASE)
+    result = result.replace("..", ".")
+    result = re.sub(r"\s+([)\]}])", r"\1", result)
+    result = re.sub(r"([(\[{])\s+", r"\1", result)
+    result = re.sub(r"\s{2,}", " ", result)
+    return result.strip()

--- a/sync_config.py
+++ b/sync_config.py
@@ -1,5 +1,6 @@
 import os
 import re
+import time
 from file_permissions import sanitize_file_permission_mask
 
 # Settings are stored in SQLite (``app_config`` table under ``DATA_DIR/db/``).
@@ -53,7 +54,17 @@ def sanitize_sync_cron(expr: str | None) -> str:
     return " ".join(parts)
 
 
+_settings_cache: dict | None = None
+_settings_cache_at: float = 0.0
+_SETTINGS_CACHE_TTL = 5.0
+
+
 def load_settings() -> dict:
+    global _settings_cache, _settings_cache_at
+    now = time.monotonic()
+    if _settings_cache is not None and (now - _settings_cache_at) < _SETTINGS_CACHE_TTL:
+        return _settings_cache
+
     from db import init_db, read_stored_settings
 
     conn = init_db()
@@ -68,10 +79,14 @@ def load_settings() -> dict:
     out["volume_naming"] = sanitize_volume_naming(out.get("volume_naming"))
     out["sync_cron"] = sanitize_sync_cron(out.get("sync_cron"))
     out["file_permission_mask"] = sanitize_file_permission_mask(out.get("file_permission_mask"))
+    _settings_cache = out
+    _settings_cache_at = now
     return out
 
 
 def save_settings(data: dict):
+    global _settings_cache_at
+    _settings_cache_at = 0.0  # invalidate cache
     data = dict(data)
     data.pop("volume_mode", None)
     data.pop("merge_volume_naming", None)

--- a/web/app.py
+++ b/web/app.py
@@ -18,6 +18,7 @@ from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel, Field
 
 MANGA_ROOT = os.environ.get("MANGA_ROOT", "/manga")
+_MANGA_ROOT_REAL = os.path.realpath(MANGA_ROOT)
 DATA_DIR   = os.environ.get("DATA_DIR",   "/data")
 SYNC_LOG   = os.environ.get("SYNC_LOG",   "/data/logs/sync.log")
 MDEX_BASE  = "https://api.mangadex.org"
@@ -90,11 +91,11 @@ _WEB_DIR = os.path.dirname(os.path.abspath(__file__))
 _REPO_ROOT = os.path.dirname(_WEB_DIR)
 MANGA_SYNC_SCRIPT = os.path.join(_REPO_ROOT, "manga-sync.py")
 
-_spec = importlib.util.spec_from_file_location("manga_fix", "/app/manga-fix.py")
+_spec = importlib.util.spec_from_file_location("manga_fix", os.path.join(_REPO_ROOT, "manga-fix.py"))
 _fix  = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_fix)
 
-sys.path.insert(0, "/app")
+sys.path.insert(0, _REPO_ROOT)
 from sync_config import (  # noqa: E402
     load_settings,
     save_settings,
@@ -110,13 +111,47 @@ from comicinfo import (                                # noqa: E402
 )
 from comicinfo_defs import MANGA_VALUES, AGE_RATING_VALUES  # noqa: E402
 from file_permissions import sanitize_file_permission_mask   # noqa: E402
+from naming import apply_naming_template, format_num, floor_int_str  # noqa: E402
 
-app = FastAPI(title="Manga Maid")
-templates = Jinja2Templates(directory="/app/web/templates")
+
+@contextlib.asynccontextmanager
+async def _lifespan(app: FastAPI):
+    loop = asyncio.get_event_loop()
+    await loop.run_in_executor(None, _get_conn)
+    cron_expr = sanitize_sync_cron(load_settings().get("sync_cron"))
+    try:
+        await loop.run_in_executor(None, _write_runtime_crontab, cron_expr)
+    except Exception as e:
+        print(f"[startup] warning: could not write runtime crontab '{RUNTIME_CRONTAB_PATH}': {e}")
+    _job_worker_stop.clear()
+    with contextlib.suppress(Exception):
+        _enqueue_reconcile_job("startup")
+    global _job_worker_task, _reconcile_scheduler_task
+    _job_worker_task = asyncio.create_task(_jobs_worker_loop())
+    _reconcile_scheduler_task = asyncio.create_task(_reconcile_scheduler_loop())
+
+    yield
+
+    _job_worker_stop.set()
+    if _reconcile_scheduler_task:
+        _reconcile_scheduler_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await _reconcile_scheduler_task
+        _reconcile_scheduler_task = None
+    if _job_worker_task:
+        _job_worker_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await _job_worker_task
+        _job_worker_task = None
+
+
+app = FastAPI(title="Manga Maid", lifespan=_lifespan)
+templates = Jinja2Templates(directory=os.path.join(_WEB_DIR, "templates"))
 templates.env.filters["urlencode"] = quote_plus
 
 _sync_running = False
 _cover_cache: dict[str, bytes] = {}
+_COVER_CACHE_MAX = 500
 _conn = None  # shared SQLite connection (WAL mode, safe for single-writer)
 _job_worker_task: asyncio.Task | None = None
 _reconcile_scheduler_task: asyncio.Task | None = None
@@ -210,42 +245,6 @@ async def _reconcile_scheduler_loop() -> None:
             _enqueue_reconcile_job("periodic")
 
 
-@app.on_event("startup")
-async def _startup():
-    loop = asyncio.get_event_loop()
-    await loop.run_in_executor(None, _get_conn)
-    # Keep runtime scheduler synced with persisted settings on boot.
-    cron_expr = sanitize_sync_cron(load_settings().get("sync_cron"))
-    try:
-        await loop.run_in_executor(None, _write_runtime_crontab, cron_expr)
-    except Exception as e:
-        # Do not fail app startup if crontab rewrite is not writable
-        # (e.g. non-root app user with root-owned crontab file).
-        print(f"[startup] warning: could not write runtime crontab '{RUNTIME_CRONTAB_PATH}': {e}")
-    _job_worker_stop.clear()
-    with contextlib.suppress(Exception):
-        _enqueue_reconcile_job("startup")
-    global _job_worker_task, _reconcile_scheduler_task
-    _job_worker_task = asyncio.create_task(_jobs_worker_loop())
-    _reconcile_scheduler_task = asyncio.create_task(_reconcile_scheduler_loop())
-
-
-@app.on_event("shutdown")
-async def _shutdown():
-    _job_worker_stop.set()
-    global _job_worker_task, _reconcile_scheduler_task
-    if _reconcile_scheduler_task:
-        _reconcile_scheduler_task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await _reconcile_scheduler_task
-        _reconcile_scheduler_task = None
-    if _job_worker_task:
-        _job_worker_task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await _job_worker_task
-        _job_worker_task = None
-
-
 def _job_display_name(job: dict) -> str:
     if job.get("job_type") == JOB_TYPE_RECONCILE_DISK:
         return "Disk reconcile"
@@ -293,8 +292,8 @@ async def _run_job(job: dict) -> None:
     _db.append_job_log(conn, job_id, f"[job] started: {_job_display_name(job)}")
     try:
         proc = await asyncio.create_subprocess_exec(
-            "python3",
-            "/app/manga-sync.py",
+            sys.executable,
+            MANGA_SYNC_SCRIPT,
             *argv,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
@@ -347,11 +346,6 @@ async def _jobs_worker_loop():
     _db.cleanup_old_jobs(conn, keep_days=JOB_RETENTION_DAYS)
     while not _job_worker_stop.is_set():
         try:
-            if _worker_current_job_id is None:
-                recovered = _db.requeue_running_jobs(conn, queue_key=JOB_QUEUE_KEY)
-                for jid in recovered:
-                    with contextlib.suppress(Exception):
-                        _db.append_job_log(conn, jid, "[job] recovered by worker; re-queued")
             job = _db.claim_next_queued_job(conn, queue_key=JOB_QUEUE_KEY)
             if not job:
                 await asyncio.sleep(0.4)
@@ -377,64 +371,8 @@ def _cover_url(manga_id: str, filename: str) -> str:
     return f"/api/proxy/cover/{manga_id}/{filename}"
 
 
-def _safe_filename_token(value) -> str:
-    return re.sub(r'[<>:"/\\|?*]', "_", str(value or ""))
 
 
-def _format_num(value) -> str:
-    if value is None:
-        return ""
-    try:
-        num = float(value)
-    except (TypeError, ValueError):
-        return str(value)
-    return str(int(num)) if num.is_integer() else str(num)
-
-
-def _floor_int_str(value) -> str:
-    try:
-        return str(math.floor(float(value)))
-    except (TypeError, ValueError):
-        return _format_num(value)
-
-
-def _apply_naming_template(
-    template: str,
-    *,
-    language: str = "",
-    group: str = "",
-    title: str = "",
-    volume_num=None,
-    chapter_num=None,
-    chapter_title: str = "",
-    chapter_range: str = "",
-) -> str:
-    result = template or ""
-    if volume_num is None:
-        # Drop common "vol.%4" snippets when volume is unknown.
-        result = re.sub(r"\bvol(?:ume)?\.?\s*%4\b", "", result, flags=re.IGNORECASE)
-        result = re.sub(r"\bvol(?:ume)?\.?\s*$", "", result, flags=re.IGNORECASE)
-    if chapter_num is None and not chapter_range:
-        # When no chapter span is known for a volume, drop common "ch.%5" snippets
-        # so we don't generate names like "... ch.".
-        result = re.sub(r"\bch\.?\s*%5\b", "", result, flags=re.IGNORECASE)
-    result = result.replace("%1", _safe_filename_token(language))
-    result = result.replace("%2", _safe_filename_token(group))
-    result = result.replace("%3", _safe_filename_token(title))
-    result = result.replace("%4", _format_num(volume_num))
-    result = result.replace("%5", chapter_range or _format_num(chapter_num))
-    result = result.replace("%6", _safe_filename_token(chapter_title))
-    # Drop empty grouping wrappers left by missing placeholders like %2.
-    result = re.sub(r"\(\s*\)", "", result)
-    result = re.sub(r"\[\s*\]", "", result)
-    result = re.sub(r"\{\s*\}", "", result)
-    result = re.sub(r"\bch\.?\s*$", "", result, flags=re.IGNORECASE)
-    result = re.sub(r"\bvol(?:ume)?\.?\s*$", "", result, flags=re.IGNORECASE)
-    result = result.replace("..", ".")
-    result = re.sub(r"\s+([)\]}])", r"\1", result)
-    result = re.sub(r"([(\[{])\s+", r"\1", result)
-    result = re.sub(r"\s{2,}", " ", result)
-    return result.strip()
 
 
 def _mdex_tankobon_volume_count_from_aggregate(agg) -> int:
@@ -540,7 +478,7 @@ def _scan_settings_naming_issues(series_path: str | None = None) -> list[tuple[s
         # named with series-level info only — no per-chapter title/group
         # leaking into the proposed filename.
         is_on_disk = row["chapter_status"] == "on_disk"
-        new_stem = _apply_naming_template(
+        new_stem = apply_naming_template(
             chapter_tpl,
             language=row["series_language"] or "en",
             group="" if is_on_disk else (row["group_name"] or row["preferred_group"] or ""),
@@ -550,7 +488,7 @@ def _scan_settings_naming_issues(series_path: str | None = None) -> list[tuple[s
             chapter_title="" if is_on_disk else (row["chapter_title"] or ""),
         )
         # Guard against dangerous suggestions that drop chapter identity.
-        ch_token = _format_num(row["chapter_num"])
+        ch_token = format_num(row["chapter_num"])
         if ch_token and ch_token not in new_stem:
             continue
         if not new_stem or new_stem == stem:
@@ -588,10 +526,10 @@ def _scan_settings_naming_issues(series_path: str | None = None) -> list[tuple[s
         ch_range = ""
         if min_max:
             start, end = min_max
-            s_start = _floor_int_str(start)
-            s_end = _floor_int_str(end)
+            s_start = floor_int_str(start)
+            s_end = floor_int_str(end)
             ch_range = s_start if s_start == s_end else f"{s_start}-{s_end}"
-        new_stem = _apply_naming_template(
+        new_stem = apply_naming_template(
             volume_tpl,
             language=row["series_language"] or "en",
             group=row["preferred_group"] or "",
@@ -846,6 +784,13 @@ def _require_root_folders() -> None:
             400,
             "Configure at least one root folder in Settings before running this action.",
         )
+
+
+def _require_under_manga_root(path: str) -> None:
+    """Raise 400 if resolved path escapes MANGA_ROOT (guards against .. traversal)."""
+    target = os.path.realpath(path)
+    if target != _MANGA_ROOT_REAL and not target.startswith(_MANGA_ROOT_REAL + os.sep):
+        raise HTTPException(400, "Invalid path: must be under the manga root")
 
 
 class DeleteSeriesFilesBody(BaseModel):
@@ -1391,6 +1336,8 @@ async def proxy_cover(manga_id: str, filename: str):
             )
         except Exception:
             raise HTTPException(404)
+        if len(_cover_cache) >= _COVER_CACHE_MAX:
+            _cover_cache.pop(next(iter(_cover_cache)))
         _cover_cache[cache_key] = data
     return Response(_cover_cache[cache_key], media_type="image/jpeg",
                     headers={"Cache-Control": "public, max-age=86400"})
@@ -1429,6 +1376,7 @@ async def add_series(
     _require_root_folders()
     parts      = [p for p in [subfolder.strip("/"), title] if p]
     series_dir = os.path.join(MANGA_ROOT, *parts)
+    _require_under_manga_root(series_dir)
     os.makedirs(series_dir, exist_ok=True)
     rel_path   = os.path.relpath(series_dir, MANGA_ROOT)
 
@@ -1632,6 +1580,7 @@ async def update_series(
     old_dir    = os.path.join(MANGA_ROOT, path)
     parts      = [p for p in [subfolder.strip("/"), title] if p]
     new_dir    = os.path.join(MANGA_ROOT, *parts)
+    _require_under_manga_root(new_dir)
     new_rel    = os.path.relpath(new_dir, MANGA_ROOT)
 
     if os.path.abspath(old_dir) != os.path.abspath(new_dir):
@@ -1930,7 +1879,7 @@ async def series_covers(path: str):
         return JSONResponse({"ok": False, "error": "Kavita not configured in settings"})
     try:
         proc = await asyncio.create_subprocess_exec(
-            "python3", "/app/manga-sync.py",
+            sys.executable, MANGA_SYNC_SCRIPT,
             "--series", os.path.join(MANGA_ROOT, path),
             "--covers-only",
             stdout=asyncio.subprocess.PIPE,
@@ -2184,9 +2133,9 @@ async def get_chapter_comicinfo(path: str, chapter_id: int):
     if not fields.get("Manga"):
         fields["Manga"] = "YesAndRightToLeft"
     if not fields.get("Number") and r["chapter_num"] is not None:
-        fields["Number"] = _format_num(r["chapter_num"])
+        fields["Number"] = format_num(r["chapter_num"])
     if not fields.get("Volume") and r["volume_num"] is not None:
-        fields["Volume"] = _format_num(r["volume_num"])
+        fields["Volume"] = format_num(r["volume_num"])
     if not fields.get("Title") and r["title"]:
         fields["Title"] = str(r["title"]).strip()
     return JSONResponse({
@@ -2254,7 +2203,7 @@ async def get_volume_comicinfo(path: str, volume_id: int):
     if not fields.get("Manga"):
         fields["Manga"] = "YesAndRightToLeft"
     if not fields.get("Volume") and r["volume_num"] is not None:
-        fields["Volume"] = _format_num(r["volume_num"])
+        fields["Volume"] = format_num(r["volume_num"])
     if not fields.get("Title") and r["title"]:
         fields["Title"] = r["title"]
     return JSONResponse({
@@ -2311,6 +2260,7 @@ async def apply_fix(
     issue_name: str = Form(...),
 ):
     _require_root_folders()
+    _require_under_manga_root(old_path)
     log_path = os.path.join(MANGA_ROOT, _fix.LOG_FILENAME)
     log_data = _fix.load_log(log_path)
     try:


### PR DESCRIPTION
…cations

- Add naming.py: single source of truth for filename template logic (replaces _apply_template/_apply_chapter_template in manga-sync.py and _apply_naming_template/_safe_filename_token/_format_num/_floor_int_str in web/app.py)
- Fix crash: add missing contextlib and json imports in manga-sync.py
- Fix hardcoded /app/ paths in web/app.py; use _REPO_ROOT/_WEB_DIR constants
- Replace deprecated @app.on_event with lifespan context manager (FastAPI)
- Add path traversal guard (_require_under_manga_root) on add/update/fix endpoints
- Cache os.path.realpath(MANGA_ROOT) at module level as _MANGA_ROOT_REAL
- Add TTL settings cache in sync_config.py (5s, invalidated on save)
- Add bounded cover image cache (FIFO eviction at 500 entries)
- Remove dead import stub for manga_sync_helpers.fetch_volume_covers
- Remove redundant requeue_running_jobs call from idle worker poll loop
- Use sys.executable instead of hardcoded python3 for subprocess spawns